### PR TITLE
chore: set up gitflow branching, PR/issue templates, and OSS docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,64 @@
+name: Bug report
+description: Report something that isn't working as expected
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug! Please fill out the sections below.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: A clear description of the bug.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      value: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: browbro version
+      placeholder: e.g. 0.3.0 (Settings → About)
+    validations:
+      required: true
+
+  - type: input
+    id: macos-version
+    attributes:
+      label: macOS version
+      placeholder: e.g. macOS 15.1 Sequoia
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs or screenshots
+      description: Drag and drop screenshots here, or paste any console/log output.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched existing issues and this hasn't been reported yet.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/tiagomoraes/browbro/security/advisories/new
+    about: Please report security vulnerabilities privately, not as a public issue.
+  - name: Ask a question / discuss an idea
+    url: https://github.com/tiagomoraes/browbro/discussions
+    about: For open-ended questions or discussion, use GitHub Discussions instead of an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,38 @@
+name: Feature request
+description: Suggest an idea or enhancement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the suggestion! Please fill out the sections below.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Is your request related to a problem? Describe it.
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: What would you like to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any alternative solutions or workarounds you've considered.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched existing issues and this hasn't been requested yet.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,33 @@
+## Summary
+
+<!-- What does this PR do, and why? -->
+
+Closes #<!-- issue number, if any -->
+
+## Type of change
+
+- [ ] `feat` — new feature
+- [ ] `fix` — bug fix
+- [ ] `chore` — maintenance, tooling, deps
+- [ ] `docs` — documentation only
+- [ ] `refactor` — no behavior change
+- [ ] `test` — tests only
+- [ ] `perf` — performance improvement
+- [ ] `ci` / `build` — CI or build system
+- [ ] `style` — formatting only
+
+## Target branch
+
+- [ ] This PR targets `develop` (default for `feat/`, `fix/`, `chore/`, etc.)
+- [ ] This is a `hotfix/` PR and intentionally targets `main`
+
+## How was this tested?
+
+<!-- Steps you took to verify the change, e.g. manual testing on macOS <version>, added tests, etc. -->
+
+## Checklist
+
+- [ ] My branch follows the naming convention (`feat/`, `fix/`, `chore/`, ...) — see [CONTRIBUTING.md](../CONTRIBUTING.md)
+- [ ] My PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (it becomes the squash-merge commit message)
+- [ ] I've updated `CHANGELOG.md` under `[Unreleased]` if this is a user-facing change
+- [ ] I've updated documentation if needed

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,29 @@
+enhancement:
+  - head-branch: ['^feat/']
+
+bug:
+  - head-branch: ['^fix/']
+
+documentation:
+  - head-branch: ['^docs/']
+
+chore:
+  - head-branch: ['^chore/']
+
+refactor:
+  - head-branch: ['^refactor/']
+
+test:
+  - head-branch: ['^test/']
+
+performance:
+  - head-branch: ['^perf/']
+
+ci:
+  - head-branch: ['^ci/']
+
+build:
+  - head-branch: ['^build/']
+
+style:
+  - head-branch: ['^style/']

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,18 @@
+name: Labeler
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          configuration-path: .github/labeler.yml
+          sync-labels: true

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -1,0 +1,51 @@
+name: PR lint
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  pr-title:
+    name: PR Title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            chore
+            docs
+            refactor
+            test
+            perf
+            ci
+            build
+            style
+            revert
+
+  branch-name:
+    name: Branch Name
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check branch prefix
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          if [[ "$BASE_REF" == "main" && "$HEAD_REF" =~ ^hotfix/ ]]; then
+            echo "OK: hotfix branch targeting main"
+            exit 0
+          fi
+          if [[ "$HEAD_REF" =~ ^(feat|fix|chore|docs|refactor|test|perf|ci|build|style|release)/ ]]; then
+            echo "OK: $HEAD_REF"
+            exit 0
+          fi
+          echo "Branch '$HEAD_REF' doesn't match an allowed prefix (feat/, fix/, chore/, docs/, refactor/, test/, perf/, ci/, build/, style/, release/, hotfix/)."
+          echo "See CONTRIBUTING.md for the naming convention."
+          exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Project scaffolding: Gitflow branching model, contribution guidelines, issue/PR templates.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,56 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a
+harassment-free experience for everyone, regardless of age, body size, visible or invisible
+disability, ethnicity, sex characteristics, gender identity and expression, level of experience,
+education, socio-economic status, nationality, personal appearance, race, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive,
+and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from
+  the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their
+  explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing our standards of acceptable
+behavior and will take appropriate and fair corrective action in response to any behavior that
+they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is
+officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the
+maintainer at **tiago.moraes@aca.so**. All complaints will be reviewed and investigated promptly
+and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available
+at https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+[homepage]: https://www.contributor-covenant.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,91 @@
+# Contributing to browbro
+
+Thanks for taking the time to contribute! This document explains the branching model,
+naming conventions, and release process used in this repo.
+
+## Branching model (Gitflow-lite)
+
+This repo uses a lightweight version of [Gitflow](https://nvie.com/posts/a-successful-git-branching-model/)
+with two long-lived branches:
+
+| Branch    | Purpose                                              | Protected |
+|-----------|-------------------------------------------------------|-----------|
+| `main`    | Always production-ready. Every commit is a tagged release. | Yes |
+| `develop` | Integration branch for the next release. **Default branch** — PRs target this. | Yes |
+
+All day-to-day work (features, fixes, chores, docs, etc.) branches off `develop` and is merged
+back into `develop` via pull request. `main` only moves forward through release or hotfix PRs.
+
+## Branch naming
+
+Prefix your branch with the type of change, followed by a short, kebab-case description:
+
+```
+<type>/<short-description>
+```
+
+| Prefix       | Use for                                                        |
+|--------------|-----------------------------------------------------------------|
+| `feat/`      | A new feature                                                  |
+| `fix/`       | A bug fix                                                       |
+| `chore/`     | Maintenance that doesn't change app behavior (tooling, deps)   |
+| `docs/`      | Documentation only                                              |
+| `refactor/`  | Code change that neither fixes a bug nor adds a feature         |
+| `test/`      | Adding or correcting tests                                      |
+| `perf/`      | Performance improvements                                        |
+| `ci/`        | CI configuration and scripts                                    |
+| `build/`     | Build system or dependency changes                              |
+| `style/`     | Formatting only, no code meaning change                         |
+| `release/`   | Release stabilization branch, maintainers only (see below)      |
+| `hotfix/`    | Urgent fix branched from `main`, maintainers only (see below)    |
+
+Examples: `feat/menu-bar-browser-picker`, `fix/default-browser-detection`, `docs/readme-setup`.
+
+A CI check enforces this on every PR.
+
+## Commit messages & PR titles
+
+Please follow [Conventional Commits](https://www.conventionalcommits.org/) for your PR title
+(e.g. `feat: add menu bar browser picker`, `fix: correct default browser detection`). PRs are
+squash-merged, and the PR title becomes the commit message on `develop`/`main`, so a clean,
+conventional title keeps history and changelogs useful. A CI check enforces this on every PR.
+
+## Contributing a change
+
+1. Fork the repo (external contributors) or branch directly (maintainers).
+2. Create a branch off `develop` using the naming convention above.
+3. Make your change, with tests where it makes sense.
+4. Open a pull request **against `develop`** (this is the default, so you shouldn't need to
+   change anything). Fill in the PR template.
+5. Address review feedback. Once checks pass, the PR is squash-merged.
+
+## Release process
+
+Releases are cut from `develop` onto `main` and tagged with [SemVer](https://semver.org/)
+(`vMAJOR.MINOR.PATCH`).
+
+1. When `develop` is ready to ship, open a PR from `develop` into `main`.
+   - For a larger release that needs stabilization time, cut a `release/x.y.z` branch from
+     `develop` instead, allow only fixes/docs/version-bump commits on it, then PR that branch
+     into `main` (and merge it back into `develop` afterwards so those last-minute fixes aren't
+     lost).
+2. Update `CHANGELOG.md`, moving the relevant `[Unreleased]` entries under a new
+   `[x.y.z] - YYYY-MM-DD` heading.
+3. Merge the PR into `main`.
+4. Tag the merge commit: `git tag vX.Y.Z && git push origin vX.Y.Z`.
+5. Publish a GitHub Release from the tag, using "Generate release notes" (PRs are auto-labeled
+   by type, so the notes come out categorized).
+
+### Hotfixes
+
+For an urgent fix to a released version that can't wait for the next `develop` → `main` cycle:
+
+1. Branch `hotfix/x.y.z` from `main`.
+2. Fix, then PR **into `main`** (this is the one case where a PR doesn't target `develop`).
+3. Tag and release as above.
+4. Merge/cherry-pick the same fix back into `develop` so it isn't lost in the next release.
+
+## Code of Conduct
+
+This project follows the [Contributor Covenant](CODE_OF_CONDUCT.md). By participating, you're
+expected to uphold it.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # browbro
 BowBro is a macos application that let's the user select the browser they want to use to open a link from the web.
+
+## Contributing
+
+Contributions are welcome! Active development happens on the `develop` branch — `main` is
+reserved for tagged releases. Please read [CONTRIBUTING.md](CONTRIBUTING.md) for the branching
+model, naming conventions, and release process, and [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
+before opening an issue or pull request.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,21 @@
+# Security Policy
+
+## Supported Versions
+
+browbro is pre-1.0 and does not yet maintain multiple supported release lines. Security fixes are
+released against the latest version on `main`.
+
+## Reporting a Vulnerability
+
+Please **do not** open a public GitHub issue for security vulnerabilities.
+
+Instead, report it privately using one of these channels:
+
+- [GitHub private vulnerability reporting](../../security/advisories/new) for this repository
+  (preferred), or
+- Email **tiago.moraes@aca.so** with details and reproduction steps.
+
+This is a solo-maintained open-source project, so there's no fixed SLA, but reports are
+prioritized and you'll get an acknowledgment as soon as possible. Once a fix is available, a
+GitHub Security Advisory and a patched release will be published, and you'll be credited unless
+you prefer to stay anonymous.


### PR DESCRIPTION
## Summary

- Adds the Gitflow-lite branching model + naming convention docs (CONTRIBUTING.md)
- Adds CODE_OF_CONDUCT.md, SECURITY.md, CHANGELOG.md
- Adds GitHub issue forms (bug report, feature request) and a PR template
- Adds CI to lint PR titles (Conventional Commits) and branch names, plus auto-labeling by branch prefix
- `develop` is now the default branch; `main` is reserved for releases

Closes the initial repo bootstrap requested for browbro.

## Type of change

- [x] `chore` — maintenance, tooling, deps

## Target branch

- [x] This PR targets `develop`

## How was this tested?

N/A — documentation and repo configuration only. CI checks on this PR validate the PR title and branch name lint themselves.