### PR TITLE
fix: working download button + v0.1.0 release prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0] - 2026-07-04
+
+First public preview. Universal (Apple Silicon + Intel) build, code-signed but not
+yet notarized, so the first launch needs a manual "Open Anyway" (see the release notes).
+
 ### Added
 
-- The cursor picker: a keyboard-first popover at the click point — `1`–`9` opens a target
+- The cursor picker: a keyboard-first popover at the click point. `1`–`9` opens a target
   directly, `↑`/`↓` and first-letter jumps move the highlight, `Enter` opens, `Esc` cancels.
   Browsers and Chrome profiles appear as peers in one flat list, with profile color swatches
   and quick-key badges.
@@ -23,4 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - BrowBro brand: the unibrow logomark, a monochrome menu-bar template glyph, the blue-squircle
   app icon, and a full set of native design tokens (adaptive light/dark) from the BrowBro
   Design System.
+- Marketing website (static, in `site/`) published to GitHub Pages at browbro.tiagomoraes.cloud.
 - Project scaffolding: Gitflow branching model, contribution guidelines, issue/PR templates.
+
+[Unreleased]: https://github.com/tiagomoraes/browbro/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/tiagomoraes/browbro/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ BowBro is a macos application that let's the user select the browser they want t
 
 ## Website
 
-The marketing site lives in [`site/`](site/) — a self-contained static site (no build
+The marketing site lives in [`site/`](site/): a self-contained static site (no build
 step) that mirrors the app's design system. It's published to GitHub Pages at
 **[browbro.tiagomoraes.cloud](https://browbro.tiagomoraes.cloud)** by the
 [`deploy-pages`](.github/workflows/deploy-pages.yml) workflow on every push to `develop`
@@ -12,7 +12,7 @@ the printed URL.
 
 ## Contributing
 
-Contributions are welcome! Active development happens on the `develop` branch — `main` is
+Contributions are welcome! Active development happens on the `develop` branch. `main` is
 reserved for tagged releases. Please read [CONTRIBUTING.md](CONTRIBUTING.md) for the branching
 model, naming conventions, and release process, and [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
 before opening an issue or pull request.

--- a/site/app.js
+++ b/site/app.js
@@ -1,5 +1,5 @@
 /* =============================================================================
-   BrowBro website — interactivity
+   BrowBro website: interactivity
    A faithful vanilla-JS port of the prototype's DCLogic: theme toggle, brew
    copy, the live cursor picker (autoplay + keyboard nav + launch choreography),
    the FAQ accordion, and the Settings toggles + drag-to-reorder.
@@ -88,7 +88,7 @@
   }
 
   /* -------------------------------------------------------------------------
-     Data — dummy browsers + Chrome profiles (not the user's real ones)
+     Data: dummy browsers + Chrome profiles (not the user's real ones)
   ------------------------------------------------------------------------- */
   var TARGETS = [
     { name: 'Personal', key: '1', profile: true, color: '#7c5cff', detail: 'alex@gmail.com' },
@@ -151,7 +151,7 @@
   })();
 
   /* =========================================================================
-     HERO — static decorative picker rows (Personal preselected)
+     HERO: static decorative picker rows (Personal preselected)
   ========================================================================= */
   (function () {
     var host = document.getElementById('hero-rows');
@@ -162,7 +162,7 @@
   })();
 
   /* =========================================================================
-     LIVE DEMO — cursor picker with autoplay, keyboard nav, launch bloom
+     LIVE DEMO: cursor picker with autoplay, keyboard nav, launch bloom
   ========================================================================= */
   (function () {
     var stage = document.getElementById('demo-stage');
@@ -371,7 +371,7 @@
   })();
 
   /* =========================================================================
-     CUSTOMIZE — Settings toggles + drag reorder
+     CUSTOMIZE: Settings toggles + drag reorder
   ========================================================================= */
   (function () {
     var list = document.getElementById('settings-list');
@@ -441,7 +441,7 @@
   })();
 
   /* =========================================================================
-     FAQ accordion — one open at a time
+     FAQ accordion: one open at a time
   ========================================================================= */
   (function () {
     var listEl = document.getElementById('faq-list');

--- a/site/index.html
+++ b/site/index.html
@@ -4,8 +4,8 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 
-<title>BrowBro — Every link, your call.</title>
-<meta name="description" content="BrowBro is an open-source macOS menu-bar app that pops a tiny picker at your cursor the instant you click a link — choose a browser, or the right Chrome profile, by keyboard or mouse.">
+<title>BrowBro: Every link, your call.</title>
+<meta name="description" content="BrowBro is an open-source macOS menu-bar app that pops a tiny picker at your cursor the instant you click a link. Choose a browser, or the right Chrome profile, by keyboard or mouse.">
 <link rel="canonical" href="https://browbro.tiagomoraes.cloud/">
 
 <meta name="theme-color" content="#f4f6fb" media="(prefers-color-scheme: light)">
@@ -15,14 +15,14 @@
 <!-- Open Graph / Twitter -->
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="BrowBro">
-<meta property="og:title" content="BrowBro — Every link, your call.">
+<meta property="og:title" content="BrowBro: Every link, your call.">
 <meta property="og:description" content="The menu-bar browser router for macOS. Click a link, pick a browser or Chrome profile at your cursor. Open source, native, keyboard-first.">
 <meta property="og:url" content="https://browbro.tiagomoraes.cloud/">
 <meta property="og:image" content="https://browbro.tiagomoraes.cloud/assets/og-image.png">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="BrowBro — Every link, your call.">
+<meta name="twitter:title" content="BrowBro: Every link, your call.">
 <meta name="twitter:description" content="The menu-bar browser router for macOS. Every link, your call.">
 <meta name="twitter:image" content="https://browbro.tiagomoraes.cloud/assets/og-image.png">
 
@@ -56,10 +56,10 @@
   "name": "BrowBro",
   "applicationCategory": "UtilitiesApplication",
   "operatingSystem": "macOS 14 (Sonoma) or later",
-  "description": "An open-source macOS menu-bar app that pops a picker at your cursor when you click a link, so you choose which browser — or Chrome profile — opens it.",
+  "description": "An open-source macOS menu-bar app that pops a picker at your cursor when you click a link, so you choose which browser, or Chrome profile, opens it.",
   "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
   "url": "https://browbro.tiagomoraes.cloud/",
-  "downloadUrl": "https://github.com/tiagomoraes/browbro/releases",
+  "downloadUrl": "https://github.com/tiagomoraes/browbro/releases/latest/download/BrowBro.dmg",
   "license": "https://github.com/tiagomoraes/browbro/blob/develop/LICENSE"
 }
 </script>
@@ -94,7 +94,7 @@
         <!-- moon (shown in dark) -->
         <svg class="icon-moon" width="17" height="17" viewBox="0 0 24 24" fill="currentColor"><path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z"></path></svg>
       </button>
-      <a href="https://github.com/tiagomoraes/browbro/releases" target="_blank" rel="noopener" class="btn-accent">Download</a>
+      <a href="https://github.com/tiagomoraes/browbro/releases/latest/download/BrowBro.dmg" target="_blank" rel="noopener" class="btn-accent">Download</a>
     </div>
   </div>
 </nav>
@@ -106,9 +106,9 @@
   <div>
     <div class="badge">Open source · macOS 14+</div>
     <h1>Every link,<br>your call.</h1>
-    <p class="hero__sub">The instant you click a link, BrowBro pops a tiny picker at your cursor — choose a browser, or the right Chrome profile, by keyboard or mouse. Fast, native, out of the way.</p>
+    <p class="hero__sub">The instant you click a link, BrowBro pops a tiny picker at your cursor. Choose a browser, or the right Chrome profile, by keyboard or mouse. Fast, native, out of the way.</p>
     <div class="hero__actions">
-      <a href="https://github.com/tiagomoraes/browbro/releases" target="_blank" rel="noopener" class="btn-accent btn-accent--lg">
+      <a href="https://github.com/tiagomoraes/browbro/releases/latest/download/BrowBro.dmg" target="_blank" rel="noopener" class="btn-accent btn-accent--lg">
         <svg width="19" height="19" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v12M7 10l5 5 5-5"></path><path d="M4 20h16"></path></svg>
         Download for macOS
       </a>
@@ -118,7 +118,7 @@
         <span class="btn-brew__label" id="brew-label">Copy</span>
       </button>
     </div>
-    <p class="hero__fine">Free &amp; open source · macOS 14 Sonoma or later</p>
+    <p class="hero__fine">Free &amp; open source · macOS 14 Sonoma or later. <a href="https://github.com/tiagomoraes/browbro/releases/latest" target="_blank" rel="noopener" style="color:var(--accent); text-decoration:none;">First launch: how to open an unsigned app.</a></p>
   </div>
 
   <div class="scene bb-scene hero__scene">
@@ -171,7 +171,7 @@
         <div class="card__icon"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="16" rx="2.5"></rect><rect x="6" y="10.5" width="12" height="3" rx="1.2" fill="currentColor" stroke="none"></rect></svg></div>
       </div>
       <h3>Pick</h3>
-      <p>A compact picker appears right at your cursor. Choose a browser — or a Chrome profile — by mouse or keyboard.</p>
+      <p>A compact picker appears right at your cursor. Choose a browser, or a Chrome profile, by mouse or keyboard.</p>
     </div>
     <div class="card bb-reveal">
       <div class="card__top">
@@ -219,7 +219,7 @@
         </div>
         <div class="body">
           <div class="bubble bubble--first">this one's worth a watch</div>
-          <div class="bubble">take a look —
+          <div class="bubble">take a look:
             <span id="demo-link" class="msg-link" role="link" tabindex="0">youtu.be/dQw4w9WgXcQ</span>
           </div>
         </div>
@@ -237,15 +237,15 @@
     <div class="bb-reveal">
       <div class="eyebrow">Make it yours</div>
       <h2>Show only what you use.</h2>
-      <p class="lede">Choose exactly which browsers and Chrome profiles appear in the picker — flip each one on or off. Drag to reorder so the ones you reach for most sit right under your cursor.</p>
+      <p class="lede">Choose exactly which browsers and Chrome profiles appear in the picker: flip each one on or off. Drag to reorder so the ones you reach for most sit right under your cursor.</p>
       <div class="checklist">
         <div class="check-item">
           <span class="check-badge"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12l5 5 9-11"></path></svg></span>
-          <span class="txt"><strong>Toggle any target</strong> on or off — hidden ones never interrupt.</span>
+          <span class="txt"><strong>Toggle any target</strong> on or off. Hidden ones never interrupt.</span>
         </div>
         <div class="check-item">
           <span class="check-badge"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12l5 5 9-11"></path></svg></span>
-          <span class="txt"><strong>Drag to reorder</strong> — your 1–9 quick-keys follow the new order.</span>
+          <span class="txt"><strong>Drag to reorder</strong>: your 1–9 quick-keys follow the new order.</span>
         </div>
         <div class="check-item">
           <span class="check-badge"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12l5 5 9-11"></path></svg></span>
@@ -279,7 +279,7 @@
     <div class="oss__left bb-panel-pad">
       <div class="eyebrow">Open source</div>
       <h2>Built in the open, for macOS.</h2>
-      <p>A native Swift + SwiftUI menu-bar app in the spirit of Velja. Read the code, file an issue, or send a pull request — development happens on the <span class="mono">develop</span> branch.</p>
+      <p>A native Swift + SwiftUI menu-bar app in the spirit of Velja. Read the code, file an issue, or send a pull request. Development happens on the <span class="mono">develop</span> branch.</p>
       <div class="chips">
         <span class="chip">Swift + SwiftUI</span>
         <span class="chip">macOS 14+</span>
@@ -318,19 +318,19 @@
   <div class="faq-list" id="faq-list">
     <div class="faq-item is-open">
       <button class="faq-q" aria-expanded="true"><span class="q">Is BrowBro free?</span><span class="faq-chevron"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 6l6 6-6 6"></path></svg></span></button>
-      <div class="faq-a">Yes. BrowBro is open source and free to use — the whole thing lives on GitHub.</div>
+      <div class="faq-a">Yes. BrowBro is open source and free to use: the whole thing lives on GitHub.</div>
     </div>
     <div class="faq-item">
       <button class="faq-q" aria-expanded="false"><span class="q">Will it hijack my browser for good?</span><span class="faq-chevron"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 6l6 6-6 6"></path></svg></span></button>
-      <div class="faq-a">No. During setup BrowBro remembers your current default and keeps it as a target — restore it as your default anytime, in one click.</div>
+      <div class="faq-a">No. During setup BrowBro remembers your current default and keeps it as a target: restore it as your default anytime, in one click.</div>
     </div>
     <div class="faq-item">
       <button class="faq-q" aria-expanded="false"><span class="q">Does it support Chrome profiles?</span><span class="faq-chevron"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 6l6 6-6 6"></path></svg></span></button>
-      <div class="faq-a">Yes. Each Chrome profile shows up as its own target in the picker — with its color and email — so you can send a link straight into the right one.</div>
+      <div class="faq-a">Yes. Each Chrome profile shows up as its own target in the picker, with its color and email, so you can send a link straight into the right one.</div>
     </div>
     <div class="faq-item">
       <button class="faq-q" aria-expanded="false"><span class="q">Can I choose which browsers show up?</span><span class="faq-chevron"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 6l6 6-6 6"></path></svg></span></button>
-      <div class="faq-a">Yes. In Settings you decide which browsers and Chrome profiles appear in the picker — flip each one on or off, and drag to reorder so your favorites sit up top (the 1–9 quick-keys follow the order).</div>
+      <div class="faq-a">Yes. In Settings you decide which browsers and Chrome profiles appear in the picker: flip each one on or off, and drag to reorder so your favorites sit up top (the 1–9 quick-keys follow the order).</div>
     </div>
     <div class="faq-item">
       <button class="faq-q" aria-expanded="false"><span class="q">How do I pick without the mouse?</span><span class="faq-chevron"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 6l6 6-6 6"></path></svg></span></button>
@@ -342,7 +342,7 @@
     </div>
     <div class="faq-item">
       <button class="faq-q" aria-expanded="false"><span class="q">Does BrowBro see my links?</span><span class="faq-chevron"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 6l6 6-6 6"></path></svg></span></button>
-      <div class="faq-a">Everything happens locally on your Mac. BrowBro just routes the link to the browser you choose — nothing leaves your machine.</div>
+      <div class="faq-a">Everything happens locally on your Mac. BrowBro just routes the link to the browser you choose. Nothing leaves your machine.</div>
     </div>
   </div>
 </section>
@@ -358,7 +358,7 @@
         </span>
         <p>The menu-bar browser router for macOS. Every link, your call.</p>
       </div>
-      <a href="https://github.com/tiagomoraes/browbro/releases" target="_blank" rel="noopener" class="btn-accent btn-accent--md">
+      <a href="https://github.com/tiagomoraes/browbro/releases/latest/download/BrowBro.dmg" target="_blank" rel="noopener" class="btn-accent btn-accent--md">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v12M7 10l5 5 5-5"></path><path d="M4 20h16"></path></svg>
         Download for macOS
       </a>

--- a/site/styles.css
+++ b/site/styles.css
@@ -1,5 +1,5 @@
 /* =============================================================================
-   BrowBro — website styles
+   BrowBro: website styles
    Ported from the BrowBro Design System (Claude Design project). Tokens are
    copied verbatim from the design system so the site is pixel-faithful to the
    prototype; component + layout styles reproduce the .dc.html surfaces in
@@ -7,7 +7,7 @@
    ============================================================================= */
 
 /* =============================================================================
-   TOKENS — colors
+   TOKENS: colors
    ============================================================================= */
 :root {
   --accent:            #2c6bed;
@@ -56,7 +56,7 @@
 
   color-scheme: light;
 
-  /* Chrome profile colors — external content, only ever inside a swatch. */
+  /* Chrome profile colors: external content, only ever inside a swatch. */
   --chrome-blue:    #4285f4;
   --chrome-cyan:    #12b5cb;
   --chrome-green:   #1e8e3e;
@@ -117,7 +117,7 @@
 }
 
 /* =============================================================================
-   TOKENS — typography
+   TOKENS: typography
    ============================================================================= */
 :root {
   --font-sans: "Plus Jakarta Sans", -apple-system, BlinkMacSystemFont, system-ui,
@@ -160,7 +160,7 @@
 }
 
 /* =============================================================================
-   TOKENS — spacing
+   TOKENS: spacing
    ============================================================================= */
 :root {
   --space-0:  0px;
@@ -186,7 +186,7 @@
 }
 
 /* =============================================================================
-   TOKENS — shape, elevation, blur, motion
+   TOKENS: shape, elevation, blur, motion
    ============================================================================= */
 :root {
   --radius-xs:   4px;
@@ -321,7 +321,7 @@ html[data-theme="dark"] .bb-scene {
 .kbd-hint { font-family: var(--font-mono); color: var(--text-primary); }
 
 /* =============================================================================
-   BRAND — Logomark / Wordmark / MenuBarIcon
+   BRAND: Logomark / Wordmark / MenuBarIcon
    ============================================================================= */
 .wordmark {
   display: inline-flex; align-items: center;


### PR DESCRIPTION
Prep for the **v0.1.0** release and fixes the non-working Download button.

- **Download buttons** now point to `releases/latest/download/BrowBro.dmg` (a real download) instead of the empty `/releases` page. Hero adds a "first launch: how to open an unsigned app" link to the release page.
- **Copy polish**: replaced em dashes across the site, README, and changelog with `:`, `,`, `.`, or `|`.
- **CHANGELOG**: cut the dated `0.1.0` section from Unreleased.

Deploys the site on merge. The matching GitHub Release (`v0.1.0`) with the signed universal DMG is published right after, so the button resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)