### PR TITLE
fix: point Homebrew install at the browbro tap

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,23 @@
 # browbro
 BowBro is a macos application that let's the user select the browser they want to use to open a link from the web.
 
+## Install
+
+Requires macOS 14 (Sonoma) or later.
+
+**Homebrew:**
+
+```sh
+brew install --cask tiagomoraes/browbro/browbro
+```
+
+**Or download the DMG** from the [latest release](https://github.com/tiagomoraes/browbro/releases/latest)
+and drag BrowBro into Applications.
+
+BrowBro is not yet notarized, so macOS blocks it on first launch. To open it: go to
+**System Settings > Privacy & Security** and click **Open Anyway** (or run
+`xattr -dr com.apple.quarantine "/Applications/BrowBro.app"`).
+
 ## Website
 
 The marketing site lives in [`site/`](site/): a self-contained static site (no build

--- a/site/app.js
+++ b/site/app.js
@@ -134,7 +134,7 @@
     if (!btn || !label) return;
     var t;
     btn.addEventListener('click', function () {
-      var cmd = 'brew install --cask browbro';
+      var cmd = 'brew install --cask tiagomoraes/browbro/browbro';
       if (navigator.clipboard && navigator.clipboard.writeText) {
         navigator.clipboard.writeText(cmd).catch(function () {});
       } else {

--- a/site/index.html
+++ b/site/index.html
@@ -113,7 +113,7 @@
         Download for macOS
       </a>
       <button id="brew-copy" class="btn-brew" aria-label="Copy Homebrew install command">
-        <span class="btn-brew__cmd"><span class="dollar">$ </span>brew install --cask browbro</span>
+        <span class="btn-brew__cmd"><span class="dollar">$ </span>brew install --cask tiagomoraes/browbro/browbro</span>
         <span class="btn-brew__sep"></span>
         <span class="btn-brew__label" id="brew-label">Copy</span>
       </button>
@@ -299,7 +299,7 @@
         </div>
         <div class="body">
           <div class="comment"># install with Homebrew</div>
-          <div><span class="cmd">brew</span> install --cask browbro</div>
+          <div style="white-space:nowrap;"><span class="cmd">brew</span> install --cask tiagomoraes/browbro/browbro</div>
           <div class="spacer"></div>
           <div class="comment"># prove it works</div>
           <div style="white-space:nowrap;"><span class="cmd">open</span> -a BrowBro <span class="str">"https://example.com/it-works"</span></div>

--- a/site/styles.css
+++ b/site/styles.css
@@ -403,7 +403,7 @@ html[data-theme="dark"] .icon-btn .icon-moon { display: inline; }
 
 .btn-brew {
   display: inline-flex; align-items: center; gap: 12px;
-  height: 54px; padding: 0 16px 0 18px;
+  height: 54px; padding: 0 16px 0 18px; max-width: 100%;
   border-radius: 14px;
   background: var(--surface-raised); color: var(--text-primary);
   border: none; cursor: pointer;
@@ -411,7 +411,11 @@ html[data-theme="dark"] .icon-btn .icon-moon { display: inline; }
   transition: background var(--dur-fast) var(--ease-out);
 }
 .btn-brew:hover { background: var(--fill-hover); }
-.btn-brew__cmd { font: var(--weight-medium) var(--text-sm)/1 var(--font-mono); white-space: nowrap; }
+.btn-brew__cmd {
+  font: var(--weight-medium) var(--text-sm)/1 var(--font-mono); white-space: nowrap;
+  flex: 1 1 auto; min-width: 0; overflow-x: auto; scrollbar-width: none;
+}
+.btn-brew__cmd::-webkit-scrollbar { display: none; }
 .btn-brew__cmd .dollar { color: var(--text-tertiary); }
 .btn-brew__sep { width: 0.5px; height: 22px; background: var(--separator); }
 .btn-brew__label {


### PR DESCRIPTION
Makes the `brew` command on the site actually work.

A brand-new app can't go straight into homebrew-cask core (that needs notarization + notability), so BrowBro now has a tap: **[tiagomoraes/homebrew-browbro](https://github.com/tiagomoraes/homebrew-browbro)**.

```sh
brew install --cask tiagomoraes/browbro/browbro
```

- Hero pill, copy-to-clipboard string, and the open-source terminal now use the tap form.
- Hero pill scrolls internally (`overflow-x`) so the longer command never causes horizontal page overflow (verified at desktop + mobile).
- README gains an Install section.

Cask validated: `brew style` clean, `brew audit --online` passes (downloads + checksums the v0.1.0 DMG).

🤖 Generated with [Claude Code](https://claude.com/claude-code)