### PR TITLE
style: use a pipe in the page title

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 
-<title>BrowBro: Every link, your call.</title>
+<title>BrowBro | Every link, your call.</title>
 <meta name="description" content="BrowBro is an open-source macOS menu-bar app that pops a tiny picker at your cursor the instant you click a link. Choose a browser, or the right Chrome profile, by keyboard or mouse.">
 <link rel="canonical" href="https://browbro.tiagomoraes.cloud/">
 
@@ -15,14 +15,14 @@
 <!-- Open Graph / Twitter -->
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="BrowBro">
-<meta property="og:title" content="BrowBro: Every link, your call.">
+<meta property="og:title" content="BrowBro | Every link, your call.">
 <meta property="og:description" content="The menu-bar browser router for macOS. Click a link, pick a browser or Chrome profile at your cursor. Open source, native, keyboard-first.">
 <meta property="og:url" content="https://browbro.tiagomoraes.cloud/">
 <meta property="og:image" content="https://browbro.tiagomoraes.cloud/assets/og-image.png">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="BrowBro: Every link, your call.">
+<meta name="twitter:title" content="BrowBro | Every link, your call.">
 <meta name="twitter:description" content="The menu-bar browser router for macOS. Every link, your call.">
 <meta name="twitter:image" content="https://browbro.tiagomoraes.cloud/assets/og-image.png">
 


### PR DESCRIPTION
Changes the page/tab title separator to a pipe: **BrowBro | Every link, your call.** (also og:title and twitter:title).

🤖 Generated with [Claude Code](https://claude.com/claude-code)