### PR TITLE
chore: back-merge v0.1.2 into develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2] - 2026-07-04
+
+### Changed
+
+- The DMG's mounted volume now shows the BrowBro icon (instead of the generic disk icon).
+
+### Added
+
+- Notarization pipeline: `packaging/notarize/notarize-release.sh` and `docs/NOTARIZING.md`
+  for producing a signed + notarized DMG once a Developer ID certificate is available. Opt-in;
+  the default build is unchanged. The app itself is unchanged from 0.1.0.
+
 ## [0.1.1] - 2026-07-04
 
 ### Changed
@@ -39,6 +51,7 @@ yet notarized, so the first launch needs a manual "Open Anyway" (see the release
 - Marketing website (static, in `site/`) published to GitHub Pages at browbro.tiagomoraes.cloud.
 - Project scaffolding: Gitflow branching model, contribution guidelines, issue/PR templates.
 
-[Unreleased]: https://github.com/tiagomoraes/browbro/compare/v0.1.1...HEAD
+[Unreleased]: https://github.com/tiagomoraes/browbro/compare/v0.1.2...HEAD
+[0.1.2]: https://github.com/tiagomoraes/browbro/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/tiagomoraes/browbro/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/tiagomoraes/browbro/releases/tag/v0.1.0

--- a/docs/NOTARIZING.md
+++ b/docs/NOTARIZING.md
@@ -1,0 +1,61 @@
+# Notarizing BrowBro
+
+Notarization is Apple's automated malware check. A notarized, stapled build opens
+with no "Open Anyway" detour, and it's a prerequisite for landing in homebrew-cask
+core. It requires a **paid Apple Developer Program** membership (the free "Apple
+Development" certificate used for local builds cannot notarize).
+
+## One-time setup
+
+1. **Enroll** in the [Apple Developer Program](https://developer.apple.com/programs/) ($99/yr).
+2. **Create a Developer ID Application certificate**
+   Xcode, then Settings, then Accounts, then your team, then Manage Certificates,
+   then the `+`, then "Developer ID Application". Confirm it's in your login keychain:
+   ```sh
+   security find-identity -v -p codesigning | grep "Developer ID Application"
+   ```
+3. **Store notarization credentials** as a keychain profile:
+   ```sh
+   xcrun notarytool store-credentials browbro-notary \
+     --apple-id "you@example.com" \
+     --team-id "YOURTEAMID" \
+     --password "APP-SPECIFIC-PASSWORD"
+   ```
+   Create the app-specific password at [appleid.apple.com](https://appleid.apple.com)
+   (Sign-In and Security, then App-Specific Passwords). Alternatively pass an App
+   Store Connect API key with `--key` / `--key-id` / `--issuer`.
+
+## Build a notarized DMG
+
+```sh
+pip install dmgbuild
+DEVELOPER_ID="Developer ID Application: Your Name (YOURTEAMID)" \
+NOTARY_PROFILE="browbro-notary" \
+packaging/notarize/notarize-release.sh build/BrowBro.dmg
+```
+
+The script builds a universal, hardened-runtime, Developer-ID-signed app, wraps it
+in the styled DMG (`packaging/dmg/`), submits it to Apple, waits, and staples the
+ticket. Verify:
+
+```sh
+spctl -a -t open --context context:primary-signature -vv build/BrowBro.dmg   # -> accepted
+```
+
+## Release it
+
+1. Bump `MARKETING_VERSION` in `project.yml`, update `CHANGELOG.md`.
+2. Cut `release/x.y.z`, PR into `main`, tag `vX.Y.Z` (see CONTRIBUTING.md).
+3. Upload the notarized **`BrowBro.dmg`** as the release asset (keep the exact
+   name so `releases/latest/download/BrowBro.dmg` and the website keep working).
+4. Update the cask in the [homebrew-browbro tap](https://github.com/tiagomoraes/homebrew-browbro):
+   bump `version` and `sha256`.
+5. Once notarized and reasonably popular, the cask can be submitted to
+   homebrew-cask core so the bare `brew install --cask browbro` works.
+
+## Notes
+
+- If a future feature scripts another app or needs a hardened-runtime exception,
+  add the entitlement to `packaging/notarize/BrowBro.entitlements`.
+- The default (unsigned-to-the-world) `packaging/dmg/build-dmg.sh` still works for
+  quick local/preview builds; this pipeline is only for public, notarized releases.

--- a/packaging/dmg/dmgbuild-settings.py
+++ b/packaging/dmg/dmgbuild-settings.py
@@ -9,7 +9,7 @@ appname = os.path.basename(application)
 format = "UDZO"                       # compressed, read-only
 files = [application]
 symlinks = {"Applications": "/Applications"}
-badge_icon = os.path.join(application, "Contents/Resources/AppIcon.icns")
+icon = os.path.join(application, "Contents/Resources/AppIcon.icns")
 background = os.environ["BB_BACKGROUND"]
 
 icon_size = 128

--- a/packaging/notarize/BrowBro.entitlements
+++ b/packaging/notarize/BrowBro.entitlements
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <!--
+    Minimal hardened-runtime entitlements for notarization. BrowBro receives
+    kAEGetURL Apple Events and launches browsers via LaunchServices; neither
+    needs a special entitlement. Add keys here only if a future feature does
+    (e.g. com.apple.security.automation.apple-events to script another app).
+  -->
+</dict>
+</plist>

--- a/packaging/notarize/notarize-release.sh
+++ b/packaging/notarize/notarize-release.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+#
+# Build a NOTARIZED, stapled, universal BrowBro.dmg.
+# Produces a build Gatekeeper accepts with no "Open Anyway" step.
+#
+# One-time prerequisites:
+#   1. Apple Developer Program membership (paid).
+#   2. A "Developer ID Application" certificate in your login keychain
+#      (Xcode > Settings > Accounts > Manage Certificates > + > Developer ID Application).
+#   3. notarytool credentials stored as a keychain profile, e.g.:
+#        xcrun notarytool store-credentials browbro-notary \
+#          --apple-id "you@example.com" --team-id "TEAMID" \
+#          --password "APP-SPECIFIC-PASSWORD"     # appleid.apple.com > App-Specific Passwords
+#      (or --key / --key-id / --issuer for an App Store Connect API key)
+#   4. pip install dmgbuild
+#
+# Usage:
+#   DEVELOPER_ID="Developer ID Application: Your Name (TEAMID)" \
+#   NOTARY_PROFILE="browbro-notary" \
+#   packaging/notarize/notarize-release.sh [out.dmg]
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+: "${DEVELOPER_ID:?Set DEVELOPER_ID to your 'Developer ID Application: … (TEAMID)' identity}"
+: "${NOTARY_PROFILE:?Set NOTARY_PROFILE to a notarytool keychain profile (see header)}"
+
+DD="${DD:-build/notarize-release}"
+OUT="${1:-build/BrowBro.dmg}"
+ENTITLEMENTS="packaging/notarize/BrowBro.entitlements"
+
+echo "▶ Building Release (Developer ID, hardened runtime)…"
+xcodegen generate >/dev/null
+xcodebuild -project BrowBro.xcodeproj -scheme BrowBro -configuration Release \
+  -derivedDataPath "$DD" ARCHS="arm64 x86_64" ONLY_ACTIVE_ARCH=NO \
+  CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY="$DEVELOPER_ID" \
+  PROVISIONING_PROFILE_SPECIFIER="" ENABLE_HARDENED_RUNTIME=YES -quiet
+
+APP="$DD/Build/Products/Release/BrowBro.app"
+
+echo "▶ Re-signing with hardened runtime + secure timestamp…"
+codesign --force --options runtime --timestamp \
+  --entitlements "$ENTITLEMENTS" --sign "$DEVELOPER_ID" "$APP"
+codesign --verify --strict --deep "$APP"
+
+echo "▶ Building styled DMG…"
+export BB_APP="$APP" BB_BACKGROUND="packaging/dmg/background.tiff"
+rm -f "$OUT"
+dmgbuild -s packaging/dmg/dmgbuild-settings.py "BrowBro" "$OUT"
+
+echo "▶ Notarizing (a few minutes)…"
+xcrun notarytool submit "$OUT" --keychain-profile "$NOTARY_PROFILE" --wait
+
+echo "▶ Stapling the ticket…"
+xcrun stapler staple "$OUT"
+xcrun stapler validate "$OUT"
+
+echo "✅ Notarized + stapled: $OUT"
+echo "   Gatekeeper check: spctl -a -t open --context context:primary-signature -vv \"$OUT\""

--- a/project.yml
+++ b/project.yml
@@ -7,7 +7,7 @@ options:
 settings:
   base:
     PRODUCT_BUNDLE_IDENTIFIER: so.aca.browbro
-    MARKETING_VERSION: "0.1.1"
+    MARKETING_VERSION: "0.1.2"
     CURRENT_PROJECT_VERSION: "1"
     # Swift 5 language mode keeps the prototype free of strict-concurrency
     # noise; we can tighten to Swift 6 mode once the slice is proven.


### PR DESCRIPTION
Back-merges v0.1.2 (volume icon + notarization pipeline) into `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)