### PR TITLE
fix(site): make the marketing site responsive on mobile

### DIFF
--- a/site/app.js
+++ b/site/app.js
@@ -126,6 +126,51 @@
   })();
 
   /* =========================================================================
+     MOBILE NAV MENU
+  ========================================================================= */
+  (function () {
+    var toggle = document.getElementById('nav-toggle');
+    var menu = document.getElementById('nav-menu');
+    if (!toggle || !menu) return;
+
+    function isOpen() { return menu.classList.contains('is-open'); }
+    function setOpen(open) {
+      menu.classList.toggle('is-open', open);
+      toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+      toggle.setAttribute('aria-label', open ? 'Close menu' : 'Open menu');
+    }
+    function close() { setOpen(false); }
+
+    toggle.addEventListener('click', function (e) {
+      e.stopPropagation();
+      setOpen(!isOpen());
+    });
+
+    // Any link tap closes the menu (all links are same-page anchors or GitHub).
+    menu.addEventListener('click', function (e) {
+      if (e.target.closest('a')) close();
+    });
+
+    // Tap outside the menu (and not on the toggle) dismisses it.
+    document.addEventListener('click', function (e) {
+      if (!isOpen()) return;
+      if (menu.contains(e.target) || toggle.contains(e.target)) return;
+      close();
+    });
+
+    document.addEventListener('keydown', function (e) {
+      if (e.key === 'Escape' && isOpen()) { close(); toggle.focus(); }
+    });
+
+    // Leaving the mobile breakpoint should never strand an open overlay.
+    var wide = window.matchMedia('(min-width: 901px)');
+    (wide.addEventListener ? wide.addEventListener.bind(wide, 'change')
+                           : wide.addListener.bind(wide))(function () {
+      if (wide.matches) close();
+    });
+  })();
+
+  /* =========================================================================
      BREW COPY
   ========================================================================= */
   (function () {

--- a/site/index.html
+++ b/site/index.html
@@ -95,7 +95,21 @@
         <svg class="icon-moon" width="17" height="17" viewBox="0 0 24 24" fill="currentColor"><path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z"></path></svg>
       </button>
       <a href="https://github.com/tiagomoraes/browbro/releases/latest/download/BrowBro.dmg" target="_blank" rel="noopener" class="btn-accent">Download</a>
+      <button id="nav-toggle" class="icon-btn nav-burger" aria-label="Open menu" aria-expanded="false" aria-controls="nav-menu">
+        <!-- hamburger (closed) -->
+        <svg class="icon-burger" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M4 7h16M4 12h16M4 17h16"></path></svg>
+        <!-- close (open) -->
+        <svg class="icon-close" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M6 6l12 12M18 6L6 18"></path></svg>
+      </button>
     </div>
+  </div>
+
+  <div id="nav-menu" class="nav-menu">
+    <a href="#how">How it works</a>
+    <a href="#demo">Demo</a>
+    <a href="#customize">Customize</a>
+    <a href="#faq">FAQ</a>
+    <a href="https://github.com/tiagomoraes/browbro" target="_blank" rel="noopener">GitHub</a>
   </div>
 </nav>
 

--- a/site/styles.css
+++ b/site/styles.css
@@ -300,6 +300,9 @@ html[data-theme="dark"] .bb-scene {
 .bb-wrap { max-width: 1120px; margin: 0 auto; }
 .bb-pad  { padding-left: 28px; padding-right: 28px; }
 
+/* Offset in-page anchors so the sticky 60px nav never covers a section head. */
+section[id], #top { scroll-margin-top: 76px; }
+
 .eyebrow {
   font: var(--weight-semibold) var(--text-sm)/1 var(--font-sans);
   letter-spacing: 0.06em;
@@ -789,8 +792,58 @@ html[data-theme="dark"] .icon-btn .icon-moon { display: inline; }
 /* =============================================================================
    RESPONSIVE
    ============================================================================= */
+/* Grid/flex children default to min-width:auto, which refuses to shrink below
+   their content's min-content size and blows out the layout on narrow screens.
+   Letting these tracks/items shrink is what keeps the page free of sideways
+   scroll on mobile. */
+.hero > *,
+.grid-2 > *,
+.grid-3 > *,
+.oss > *,
+.footer__top > *,
+.hero__actions > * { min-width: 0; }
+.btn-brew { min-width: 0; }
+
+/* =============================================================================
+   MOBILE NAV MENU
+   ============================================================================= */
+.nav-burger { display: none; }
+.nav-menu   { display: none; }
+.nav-burger .icon-close { display: none; }
+.nav-burger[aria-expanded="true"] .icon-burger { display: none; }
+.nav-burger[aria-expanded="true"] .icon-close  { display: inline; }
+
 @media (max-width: 900px) {
   .nav__links { display: none; }
+  .nav-burger { display: inline-flex; }
+  .nav-menu {
+    display: block; position: fixed; left: 0; right: 0; top: 60px; z-index: 49;
+    padding: 6px 20px 14px;
+    background: var(--surface-menu);
+    -webkit-backdrop-filter: var(--blur-menu); backdrop-filter: var(--blur-menu);
+    box-shadow: inset 0 -0.5px 0 var(--separator), var(--shadow-md);
+    max-height: calc(100dvh - 60px); overflow-y: auto;
+    opacity: 0; visibility: hidden; transform: translateY(-8px);
+    transition: opacity var(--dur-panel) var(--ease-out),
+                transform var(--dur-panel) var(--ease-out),
+                visibility 0s linear var(--dur-panel);
+  }
+  .nav-menu.is-open {
+    opacity: 1; visibility: visible; transform: none;
+    transition: opacity var(--dur-panel) var(--ease-out),
+                transform var(--dur-panel) var(--ease-out);
+  }
+  .nav-menu a {
+    display: block; padding: 13px 4px; text-decoration: none;
+    color: var(--text-primary);
+    font: var(--weight-medium) var(--text-lg)/1 var(--font-sans);
+    box-shadow: inset 0 -0.5px 0 var(--separator);
+  }
+  .nav-menu a:last-child { box-shadow: none; }
+  .nav-menu a:active { color: var(--accent); }
+}
+
+@media (max-width: 900px) {
   .hero { grid-template-columns: 1fr; padding-top: 40px; gap: 36px; }
   .grid-3 { grid-template-columns: 1fr; }
   .grid-2 { grid-template-columns: 1fr; }
@@ -798,6 +851,21 @@ html[data-theme="dark"] .icon-btn .icon-moon { display: inline; }
   .bb-pad { padding-left: 20px; padding-right: 20px; }
 }
 @media (max-width: 600px) {
+  /* Compact nav so the wordmark, theme, CTA and burger fit down to 320px. */
+  .nav__inner { padding: 0 14px; gap: 8px; }
+  .nav__right { gap: 4px; }
+  .nav__right .btn-accent { padding: 0 12px; }
+  .wordmark { font-size: 20px; }
+
+  /* ID-scoped section padding wins over .bb-pad; bring it down to match. */
+  #how, #demo, #customize, #github, #faq { padding-left: 20px; padding-right: 20px; }
+
+  .hero { padding-left: 20px; padding-right: 20px; }
+  .hero__scene { min-height: 300px; padding: 16px; }
+  .hero__actions { flex-direction: column; align-items: stretch; gap: 12px; }
+  .hero__actions .btn-accent--lg { justify-content: center; }
+  .btn-brew { width: 100%; }
+
   .bb-demo-body { padding: 16px; }
   .bb-demo-anchor { left: 12px; right: 12px; top: 82px; }
   .bb-demo-anchor > .demo-pop { width: auto; }


### PR DESCRIPTION
## What & why

The marketing site had ~85px of horizontal scroll at phone widths and its nav links silently disappeared below 900px. This makes it work correctly on mobile.

## Changes

- **Kill horizontal overflow** — `min-width:0` on grid/flex children (hero, `grid-2`/`grid-3`, `oss`, `footer__top`, hero actions, brew button). The default `min-width:auto` refused to shrink below content min-content and blew out the layout (the long `brew install…` string was a big offender).
- **Mobile nav menu** — hamburger toggle + frosted-glass dropdown for the links that were hidden at ≤900px; closes on link tap, outside tap, and Escape, and resets when returning to desktop.
- **Anchor offset** — `scroll-margin-top` so section headings aren't hidden under the 60px sticky nav (also improves desktop).
- **Small-screen tuning** — compact nav down to 320px, reduced section padding, hero actions stack full-width.

## Verification

Tested in-browser via device emulation at **320 / 390 / 768 / 1280px** in both light and dark themes — zero horizontal overflow at every width, demo picker + FAQ + toggles work on touch, nav menu open/close verified, desktop layout unchanged.

Merging this to `develop` triggers the GitHub Pages deploy to browbro.tiagomoraes.cloud.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017G8mxU5aY6SJ2qvHCzHqW1