### PR TITLE
feat(site): add donation section + repo Sponsor button

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,5 @@
+# Renders the "Sponsor" button on the repo.
+# https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository
+
+github: [tiagomoraes]   # https://github.com/sponsors/tiagomoraes
+ko_fi: tiagomoraes      # https://ko-fi.com/tiagomoraes

--- a/site/index.html
+++ b/site/index.html
@@ -83,6 +83,7 @@
       <a href="#how">How it works</a>
       <a href="#demo">Demo</a>
       <a href="#customize">Customize</a>
+      <a href="#support">Support</a>
       <a href="#faq">FAQ</a>
       <a href="https://github.com/tiagomoraes/browbro" target="_blank" rel="noopener">GitHub</a>
     </div>
@@ -108,6 +109,7 @@
     <a href="#how">How it works</a>
     <a href="#demo">Demo</a>
     <a href="#customize">Customize</a>
+    <a href="#support">Support</a>
     <a href="#faq">FAQ</a>
     <a href="https://github.com/tiagomoraes/browbro" target="_blank" rel="noopener">GitHub</a>
   </div>
@@ -323,6 +325,47 @@
   </div>
 </section>
 
+<!-- ============================ SUPPORT ============================ -->
+<section id="support" class="bb-pad">
+  <div class="support bb-reveal">
+    <span class="support__glow" aria-hidden="true"></span>
+
+    <div class="eyebrow">Support the project</div>
+    <h2>Buy the bro a coffee.</h2>
+    <p class="support__lede">BrowBro is free, open source, and has no ads or tracking — and it'll stay that way. If it's earned a spot in your menu bar, a small tip helps cover what it costs to keep alive: the Apple Developer account, notarizing every release, and the nights spent building it. Any amount helps.</p>
+
+    <div class="support__costs">
+      <div class="cost">
+        <span class="cost__icon"><svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M16.365 1.43c0 1.14-.42 2.2-1.12 2.98-.75.86-1.98 1.52-3.02 1.44-.13-1.1.42-2.28 1.08-3 .74-.82 2.04-1.42 3.06-1.42zM20.5 17.02c-.55 1.27-.81 1.84-1.52 2.96-.99 1.57-2.39 3.52-4.12 3.53-1.54.02-1.94-1-4.03-.99-2.09.01-2.53 1.01-4.07.99-1.73-.01-3.05-1.78-4.04-3.35C-.02 16.76-.31 11.8 1.4 9.17c1.2-1.87 3.1-2.96 4.88-2.96 1.82 0 2.96 1 4.46 1 1.46 0 2.35-1 4.46-1 1.6 0 3.29.87 4.5 2.37-3.95 2.16-3.31 7.8.8 8.44z"></path></svg></span>
+        <span class="cost__label">Apple Developer</span>
+        <span class="cost__val">$99 / year</span>
+      </div>
+      <div class="cost">
+        <span class="cost__icon"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3l7 3v5c0 4.6-3.1 7.6-7 9-3.9-1.4-7-4.4-7-9V6l7-3z"></path><path d="M9 12l2 2 4-4.5"></path></svg></span>
+        <span class="cost__label">Notarization</span>
+        <span class="cost__val">Every release</span>
+      </div>
+      <div class="cost">
+        <span class="cost__icon"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M9 8l-4 4 4 4"></path><path d="M15 8l4 4-4 4"></path></svg></span>
+        <span class="cost__label">Development</span>
+        <span class="cost__val">Nights &amp; weekends</span>
+      </div>
+    </div>
+
+    <div class="support__actions">
+      <a href="https://github.com/sponsors/tiagomoraes" target="_blank" rel="noopener" class="btn-accent btn-accent--lg">
+        <svg width="19" height="19" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 21s-6.7-4.35-9.33-8.02C.9 10.27 1.4 6.6 4.2 5.1c2.02-1.08 4.3-.4 5.8 1.28L12 8l2-1.62c1.5-1.68 3.78-2.36 5.8-1.28 2.8 1.5 3.3 5.17 1.53 7.88C18.7 16.65 12 21 12 21z"></path></svg>
+        Sponsor on GitHub
+      </a>
+      <a href="https://ko-fi.com/tiagomoraes" target="_blank" rel="noopener" class="btn-line btn-line--lg">
+        <svg width="19" height="19" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 8h13v5a5 5 0 0 1-5 5H9a5 5 0 0 1-5-5V8z"></path><path d="M17 9h1.5a2.5 2.5 0 0 1 0 5H17"></path><path d="M8 2.5c-.5.7-.5 1.5 0 2.2M11.5 2.5c-.5.7-.5 1.5 0 2.2"></path></svg>
+        Buy me a coffee
+      </a>
+    </div>
+    <p class="support__fine">Zero platform fees · one-time or monthly · it all goes to keeping BrowBro alive. Thank you 💙</p>
+  </div>
+</section>
+
 <!-- ============================ FAQ ============================ -->
 <section id="faq" class="bb-pad">
   <div class="section-head bb-reveal">
@@ -357,6 +400,10 @@
     <div class="faq-item">
       <button class="faq-q" aria-expanded="false"><span class="q">Does BrowBro see my links?</span><span class="faq-chevron"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 6l6 6-6 6"></path></svg></span></button>
       <div class="faq-a">Everything happens locally on your Mac. BrowBro just routes the link to the browser you choose. Nothing leaves your machine.</div>
+    </div>
+    <div class="faq-item">
+      <button class="faq-q" aria-expanded="false"><span class="q">How can I support BrowBro?</span><span class="faq-chevron"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 6l6 6-6 6"></path></svg></span></button>
+      <div class="faq-a">BrowBro is free and always will be. If you'd like to help cover the running costs — the Apple Developer account, notarizing releases, and development time — you can <a href="#support" style="color:var(--accent); text-decoration:none;">sponsor it on GitHub or buy me a coffee</a>. Starring the repo and telling a friend helps just as much.</div>
     </div>
   </div>
 </section>

--- a/site/styles.css
+++ b/site/styles.css
@@ -773,6 +773,77 @@ html[data-theme="dark"] .icon-btn .icon-moon { display: inline; }
 .faq-item.is-open .faq-a { display: block; }
 
 /* =============================================================================
+   SUPPORT / DONATE
+   ============================================================================= */
+#support { padding: 24px 28px 72px; }
+.support {
+  position: relative; overflow: hidden;
+  max-width: 860px; margin: 0 auto;
+  background: var(--surface-raised);
+  border-radius: var(--radius-xl);
+  box-shadow: inset 0 0 0 0.5px var(--border-hairline), var(--shadow-md);
+  padding: 56px 44px 48px;
+  text-align: center;
+}
+/* Soft accent bloom behind the ask; purely decorative. */
+.support__glow {
+  position: absolute; left: 50%; top: -55%;
+  width: 130%; height: 130%; transform: translateX(-50%);
+  background: radial-gradient(50% 50% at 50% 50%, var(--accent-weak) 0%, transparent 70%);
+  pointer-events: none; z-index: 0;
+}
+.support > *:not(.support__glow) { position: relative; z-index: 1; }
+.support h2 {
+  margin: 0 auto; max-width: 20ch;
+  font: var(--weight-bold) clamp(28px, 3.2vw, 40px)/1.08 var(--font-sans);
+  letter-spacing: -0.02em;
+}
+.support__lede {
+  margin: 16px auto 0; max-width: 56ch;
+  font: var(--weight-regular) var(--text-md)/1.6 var(--font-sans);
+  color: var(--text-secondary);
+}
+.support__costs {
+  display: flex; flex-wrap: wrap; justify-content: center; gap: 12px;
+  margin: 32px auto 0; max-width: 600px;
+}
+.cost {
+  flex: 1 1 150px; min-width: 0;
+  display: flex; flex-direction: column; align-items: center; gap: 5px;
+  padding: 18px 14px; border-radius: var(--radius-lg);
+  background: var(--fill-quiet);
+  box-shadow: inset 0 0 0 0.5px var(--border-hairline);
+}
+.cost__icon {
+  width: 38px; height: 38px; margin-bottom: 3px; border-radius: 11px;
+  display: inline-flex; align-items: center; justify-content: center;
+  background: var(--accent-weak); color: var(--accent);
+}
+.cost__label { font: var(--weight-semibold) var(--text-md)/1.2 var(--font-sans); color: var(--text-primary); }
+.cost__val   { font: var(--weight-regular)  var(--text-sm)/1.2 var(--font-sans); color: var(--text-secondary); }
+
+.support__actions { display: flex; flex-wrap: wrap; justify-content: center; gap: 14px; margin-top: 36px; }
+.support__fine { margin: 20px 0 0; font: var(--weight-regular) var(--text-sm)/1.4 var(--font-sans); color: var(--text-tertiary); }
+
+/* Secondary large button (Ko-fi) — raised + hairline, matches btn-accent--lg height. */
+.btn-line {
+  display: inline-flex; align-items: center; gap: 10px;
+  height: 44px; padding: 0 20px;
+  border-radius: var(--radius-md);
+  background: var(--surface-raised); color: var(--text-primary);
+  font: var(--weight-semibold) var(--text-md)/1 var(--font-sans); letter-spacing: -0.01em;
+  text-decoration: none; cursor: pointer;
+  box-shadow: inset 0 0 0 0.5px var(--border-hairline), var(--shadow-sm);
+  transition: background var(--dur-fast) var(--ease-out), transform var(--dur-instant) var(--ease-out);
+}
+.btn-line:hover { background: var(--fill-hover); }
+.btn-line:active { transform: scale(0.98); }
+.btn-line--lg {
+  height: 54px; padding: 0 26px; gap: 11px;
+  border-radius: 14px; font: var(--weight-semibold) 16px/1 var(--font-sans);
+}
+
+/* =============================================================================
    FOOTER
    ============================================================================= */
 .footer { box-shadow: inset 0 0.5px 0 var(--separator); background: var(--surface-raised); }
@@ -858,7 +929,12 @@ html[data-theme="dark"] .icon-btn .icon-moon { display: inline; }
   .wordmark { font-size: 20px; }
 
   /* ID-scoped section padding wins over .bb-pad; bring it down to match. */
-  #how, #demo, #customize, #github, #faq { padding-left: 20px; padding-right: 20px; }
+  #how, #demo, #customize, #github, #support, #faq { padding-left: 20px; padding-right: 20px; }
+
+  .support { padding: 40px 22px 36px; }
+  .support__actions { flex-direction: column; align-items: stretch; }
+  .support__actions .btn-accent--lg,
+  .support__actions .btn-line--lg { justify-content: center; }
 
   .hero { padding-left: 20px; padding-right: 20px; }
   .hero__scene { min-height: 300px; padding: 16px; }


### PR DESCRIPTION
## What & why

Adds a way for people to support BrowBro and help cover its running costs — the Apple Developer account ($99/yr), notarizing every release, and development time.

## Changes

**Marketing site**
- New `#support` section ("Buy the bro a coffee.") with:
  - An honest explainer (free, open-source, no ads/tracking)
  - Three cost-breakdown cards: Apple Developer · Notarization · Development
  - Two CTAs: **Sponsor on GitHub** → `github.com/sponsors/tiagomoraes`, and **Buy me a coffee** → `ko-fi.com/tiagomoraes`
- "Support" link added to the desktop nav and mobile menu
- A matching "How can I support BrowBro?" FAQ entry that deep-links to the section
- Reuses existing design tokens, scroll-reveal, and light/dark theming; verified in light, dark, and at mobile width

**Repo**
- `.github/FUNDING.yml` so GitHub renders a "Sponsor" button on the repository

## Follow-ups (outside this PR)
- Enable **GitHub Sponsors** on the account, or the Sponsors link/entry will 404
- Create the **Ko-fi** account for the `tiagomoraes` handle
- The Sponsor button appears once this lands on the default branch (`develop`) and *Settings → Features → Sponsorships* is enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017G8mxU5aY6SJ2qvHCzHqW1