### PR TITLE
fix(app): restore Settings… (⌘,) menu command

### DIFF
--- a/Sources/BrowBroApp.swift
+++ b/Sources/BrowBroApp.swift
@@ -20,5 +20,17 @@ struct BrowBroApp: App {
             Image(nsImage: BBBrand.menuBarIcon())
         }
         .menuBarExtraStyle(.window)
+        .commands {
+            // Re-add the standard "Settings…" item (⌘,) that the removed
+            // Settings scene used to provide, wired to our manually managed
+            // window. Main-menu key equivalents fire whenever BrowBro is the
+            // active app, which is the shortcut the dropdown advertises.
+            CommandGroup(replacing: .appSettings) {
+                Button("Settings…") {
+                    SettingsWindowController.shared.show()
+                }
+                .keyboardShortcut(",", modifiers: .command)
+            }
+        }
     }
 }


### PR DESCRIPTION
## What & why

Restores the standard **Settings… (⌘,)** item in the main menu. The Settings scene that previously provided it was removed, so this re-adds the item via a `CommandGroup(replacing: .appSettings)`, wired to the manually managed settings window.

## How

```swift
CommandGroup(replacing: .appSettings) {
    Button("Settings…") {
        SettingsWindowController.shared.show()
    }
    .keyboardShortcut(",", modifiers: .command)
}
```

- Uses `SettingsWindowController.shared.show()` — the same entry point already used by `AppDelegate` and the menu-bar dropdown, so there's a single source of truth for opening Settings.
- Main-menu key equivalents fire whenever BrowBro is the active app, which matches the ⌘, shortcut the dropdown already advertises.

## Testing

Compiles cleanly (`xcodebuild … build`, signing disabled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017G8mxU5aY6SJ2qvHCzHqW1