### PR TITLE
feat(site): redesign support section as a BrowBro picker

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,53 @@
+# Product
+
+## Register
+
+brand
+
+## Users
+
+macOS users — developers, designers, consultants — who juggle several browsers or Chrome
+profiles and click links all day from Slack, Mail, Messages, and terminals. They arrive at
+the site from a friend's recommendation or a GitHub link, decide within a minute whether to
+download, and care that the app is native, fast, and trustworthy (it takes over the default
+browser, so trust is the whole game).
+
+## Product Purpose
+
+BrowBro is a free, open-source macOS menu-bar app that intercepts clicked links and pops a
+keyboard-first picker at the cursor, so every link opens in the right browser or Chrome
+profile. The site's job: demonstrate that interaction (the live demo IS the pitch), earn
+trust (open source, reversible takeover, local-only routing), and convert to a download or
+`brew install`.
+
+## Brand Personality
+
+Native, playful, trustworthy. Sounds like a helpful friend ("Every link, your call",
+"Buy the bro a coffee"); looks like macOS itself — the site is built from faux Mac windows,
+menu bars, and the app's own popover, pixel-faithful to the app's design tokens.
+
+## Anti-references
+
+- Generic SaaS landing pages: gradient meshes, hero-metric templates, pricing-tier cards.
+- Electron-app marketing that feels web-first rather than Mac-native.
+- Donation pages that guilt or gate: no tiers, no locked features, no "minimum" framing.
+
+## Design Principles
+
+1. **The UI is the illustration.** Features are shown as working facsimiles of the real app
+   (picker, settings window, terminal), never abstract art or static screenshots.
+2. **Pixel-faithful to the app.** The site consumes the app's design tokens verbatim; if it
+   wouldn't fit macOS, it doesn't ship on the site.
+3. **Keyboard-first everywhere.** Interactive demos honor the app's keys (1–9, arrows,
+   Enter, Esc).
+4. **Trust through transparency.** Open source, reversible default-browser takeover, and
+   local-only routing are stated plainly, never buried.
+5. **Asking, never pressuring.** Support is invited with warmth; free actions (starring,
+   sharing) are presented as equals to money.
+
+## Accessibility & Inclusion
+
+- Light and dark themes, honoring the system preference with a manual override.
+- `prefers-reduced-motion` respected across demos and scroll reveals.
+- Full keyboard operability with visible focus (`--focus-ring`).
+- Body text at ≥ 4.5:1 contrast in both themes.

--- a/site/app.js
+++ b/site/app.js
@@ -506,6 +506,26 @@
   })();
 
   /* =========================================================================
+     SUPPORT: picker keyboard nav (mirrors the app: arrows move, 1–3 open)
+  ========================================================================= */
+  (function () {
+    var pop = document.querySelector('.support-pick__pop');
+    if (!pop) return;
+    var rows = Array.prototype.slice.call(pop.querySelectorAll('.support-row'));
+    if (!rows.length) return;
+    // Scoped to focus-within so the shortcuts never hijack the rest of the page.
+    pop.addEventListener('keydown', function (e) {
+      var i = rows.indexOf(document.activeElement);
+      if (e.key === 'ArrowDown') { e.preventDefault(); rows[(i + 1) % rows.length].focus(); }
+      else if (e.key === 'ArrowUp') { e.preventDefault(); rows[(i - 1 + rows.length) % rows.length].focus(); }
+      else if (/^[1-9]$/.test(e.key)) {
+        var n = Number(e.key) - 1;
+        if (n < rows.length) { e.preventDefault(); rows[n].click(); }
+      }
+    });
+  })();
+
+  /* =========================================================================
      Footer year + scroll reveal
   ========================================================================= */
   (function () {

--- a/site/index.html
+++ b/site/index.html
@@ -332,37 +332,43 @@
 
     <div class="eyebrow">Support the project</div>
     <h2>Buy the bro a coffee.</h2>
-    <p class="support__lede">BrowBro is free, open source, and has no ads or tracking — and it'll stay that way. If it's earned a spot in your menu bar, a small tip helps cover what it costs to keep alive: the Apple Developer account, notarizing every release, and the nights spent building it. Any amount helps.</p>
+    <p class="support__lede">BrowBro is free, open source, and has no ads or tracking — and it'll stay that way. If it's earned its spot in your menu bar, you can help keep it there. No tiers, no minimums, no wrong answer: any amount makes a real difference, and so does a star.</p>
 
-    <div class="support__costs">
-      <div class="cost">
-        <span class="cost__icon"><svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M16.365 1.43c0 1.14-.42 2.2-1.12 2.98-.75.86-1.98 1.52-3.02 1.44-.13-1.1.42-2.28 1.08-3 .74-.82 2.04-1.42 3.06-1.42zM20.5 17.02c-.55 1.27-.81 1.84-1.52 2.96-.99 1.57-2.39 3.52-4.12 3.53-1.54.02-1.94-1-4.03-.99-2.09.01-2.53 1.01-4.07.99-1.73-.01-3.05-1.78-4.04-3.35C-.02 16.76-.31 11.8 1.4 9.17c1.2-1.87 3.1-2.96 4.88-2.96 1.82 0 2.96 1 4.46 1 1.46 0 2.35-1 4.46-1 1.6 0 3.29.87 4.5 2.37-3.95 2.16-3.31 7.8.8 8.44z"></path></svg></span>
-        <span class="cost__label">Apple Developer</span>
-        <span class="cost__val">$99 / year</span>
-      </div>
-      <div class="cost">
-        <span class="cost__icon"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3l7 3v5c0 4.6-3.1 7.6-7 9-3.9-1.4-7-4.4-7-9V6l7-3z"></path><path d="M9 12l2 2 4-4.5"></path></svg></span>
-        <span class="cost__label">Notarization</span>
-        <span class="cost__val">Every release</span>
-      </div>
-      <div class="cost">
-        <span class="cost__icon"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M9 8l-4 4 4 4"></path><path d="M15 8l4 4-4 4"></path></svg></span>
-        <span class="cost__label">Development</span>
-        <span class="cost__val">Nights &amp; weekends</span>
+    <div class="support-pick">
+      <div class="popover support-pick__pop" role="group" aria-label="Ways to support BrowBro">
+        <div class="url-header">
+          <div class="url-header__url"><span class="host">support.browbro</span><span>/any-amount</span></div>
+          <div class="url-header__from"><span>from a happy user</span></div>
+        </div>
+        <div class="popover-divider"></div>
+        <a class="support-row" href="https://github.com/sponsors/tiagomoraes" target="_blank" rel="noopener">
+          <span class="support-row__ico support-row__ico--heart"><svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 21s-6.7-4.35-9.33-8.02C.9 10.27 1.4 6.6 4.2 5.1c2.02-1.08 4.3-.4 5.8 1.28L12 8l2-1.62c1.5-1.68 3.78-2.36 5.8-1.28 2.8 1.5 3.3 5.17 1.53 7.88C18.7 16.65 12 21 12 21z"></path></svg></span>
+          <span class="support-row__text">
+            <span class="support-row__name">Sponsor on GitHub</span>
+            <span class="support-row__detail">One-time or monthly — you pick the amount</span>
+          </span>
+          <span class="keycap" aria-hidden="true">1</span>
+        </a>
+        <a class="support-row" href="https://ko-fi.com/tiagomoraes" target="_blank" rel="noopener">
+          <span class="support-row__ico support-row__ico--coffee"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 8h13v5a5 5 0 0 1-5 5H9a5 5 0 0 1-5-5V8z"></path><path d="M17 9h1.5a2.5 2.5 0 0 1 0 5H17"></path><path d="M8 2.5c-.5.7-.5 1.5 0 2.2M11.5 2.5c-.5.7-.5 1.5 0 2.2"></path></svg></span>
+          <span class="support-row__text">
+            <span class="support-row__name">Buy me a coffee</span>
+            <span class="support-row__detail">A one-off on Ko-fi — no account needed</span>
+          </span>
+          <span class="keycap" aria-hidden="true">2</span>
+        </a>
+        <a class="support-row" href="https://github.com/tiagomoraes/browbro" target="_blank" rel="noopener">
+          <span class="support-row__ico support-row__ico--star"><svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 2.6l2.9 5.88 6.5.94-4.7 4.58 1.11 6.46L12 17.4l-5.81 3.06 1.11-6.46-4.7-4.58 6.5-.94L12 2.6z"></path></svg></span>
+          <span class="support-row__text">
+            <span class="support-row__name">Star the repo</span>
+            <span class="support-row__detail">Free — and it helps more than you'd think</span>
+          </span>
+          <span class="keycap" aria-hidden="true">3</span>
+        </a>
       </div>
     </div>
 
-    <div class="support__actions">
-      <a href="https://github.com/sponsors/tiagomoraes" target="_blank" rel="noopener" class="btn-accent btn-accent--lg">
-        <svg width="19" height="19" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 21s-6.7-4.35-9.33-8.02C.9 10.27 1.4 6.6 4.2 5.1c2.02-1.08 4.3-.4 5.8 1.28L12 8l2-1.62c1.5-1.68 3.78-2.36 5.8-1.28 2.8 1.5 3.3 5.17 1.53 7.88C18.7 16.65 12 21 12 21z"></path></svg>
-        Sponsor on GitHub
-      </a>
-      <a href="https://ko-fi.com/tiagomoraes" target="_blank" rel="noopener" class="btn-line btn-line--lg">
-        <svg width="19" height="19" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 8h13v5a5 5 0 0 1-5 5H9a5 5 0 0 1-5-5V8z"></path><path d="M17 9h1.5a2.5 2.5 0 0 1 0 5H17"></path><path d="M8 2.5c-.5.7-.5 1.5 0 2.2M11.5 2.5c-.5.7-.5 1.5 0 2.2"></path></svg>
-        Buy me a coffee
-      </a>
-    </div>
-    <p class="support__fine">Zero platform fees · one-time or monthly · it all goes to keeping BrowBro alive. Thank you 💙</p>
+    <p class="support__fine">Zero platform fees · every cent goes into keeping BrowBro alive. Thank you 💙</p>
   </div>
 </section>
 
@@ -403,7 +409,7 @@
     </div>
     <div class="faq-item">
       <button class="faq-q" aria-expanded="false"><span class="q">How can I support BrowBro?</span><span class="faq-chevron"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 6l6 6-6 6"></path></svg></span></button>
-      <div class="faq-a">BrowBro is free and always will be. If you'd like to help cover the running costs — the Apple Developer account, notarizing releases, and development time — you can <a href="#support" style="color:var(--accent); text-decoration:none;">sponsor it on GitHub or buy me a coffee</a>. Starring the repo and telling a friend helps just as much.</div>
+      <div class="faq-a">BrowBro is free and always will be. If you'd like to help keep it alive, you can <a href="#support" style="color:var(--accent); text-decoration:none;">sponsor it on GitHub or buy me a coffee</a> — any amount, one-time or monthly. Starring the repo and telling a friend helps just as much.</div>
     </div>
   </div>
 </section>

--- a/site/styles.css
+++ b/site/styles.css
@@ -803,45 +803,45 @@ html[data-theme="dark"] .icon-btn .icon-moon { display: inline; }
   font: var(--weight-regular) var(--text-md)/1.6 var(--font-sans);
   color: var(--text-secondary);
 }
-.support__costs {
-  display: flex; flex-wrap: wrap; justify-content: center; gap: 12px;
-  margin: 32px auto 0; max-width: 600px;
+/* The ask, rendered as the product itself: a BrowBro picker whose targets are
+   the ways to help. The free option is a first-class row on purpose — it's the
+   design saying "no minimums" louder than any copy could. */
+.support-pick { margin: 34px auto 0; max-width: 400px; }
+.support-pick__pop { text-align: left; }
+
+.support-row {
+  display: flex; align-items: center; gap: 11px;
+  padding: 9px 10px; border-radius: var(--radius-md);
+  text-decoration: none; cursor: pointer;
+  transition: background var(--dur-instant) var(--ease-out);
 }
-.cost {
-  flex: 1 1 150px; min-width: 0;
-  display: flex; flex-direction: column; align-items: center; gap: 5px;
-  padding: 18px 14px; border-radius: var(--radius-lg);
-  background: var(--fill-quiet);
+/* Hover/focus = the app's selection state: the row fills with accent. */
+.support-row:hover, .support-row:focus-visible { background: var(--accent-fill); outline: none; }
+
+.support-row__ico {
+  flex: none; width: 34px; height: 34px; border-radius: 9px;
+  display: inline-flex; align-items: center; justify-content: center;
   box-shadow: inset 0 0 0 0.5px var(--border-hairline);
 }
-.cost__icon {
-  width: 38px; height: 38px; margin-bottom: 3px; border-radius: 11px;
-  display: inline-flex; align-items: center; justify-content: center;
-  background: var(--accent-weak); color: var(--accent);
-}
-.cost__label { font: var(--weight-semibold) var(--text-md)/1.2 var(--font-sans); color: var(--text-primary); }
-.cost__val   { font: var(--weight-regular)  var(--text-sm)/1.2 var(--font-sans); color: var(--text-secondary); }
+/* Opaque tiles so the colors hold when a row fills with accent, like real app icons. */
+.support-row__ico--heart  { background: #fae3ef; color: #c74e91; }
+.support-row__ico--coffee { background: #ffe6e5; color: #d6403c; }
+.support-row__ico--star   { background: #fcefd2; color: #b57c00; }
+html[data-theme="dark"] .support-row__ico--heart  { background: #432c39; color: #e57fb4; }
+html[data-theme="dark"] .support-row__ico--coffee { background: #442e2d; color: #ff7a77; }
+html[data-theme="dark"] .support-row__ico--star   { background: #443823; color: #f9ab00; }
 
-.support__actions { display: flex; flex-wrap: wrap; justify-content: center; gap: 14px; margin-top: 36px; }
-.support__fine { margin: 20px 0 0; font: var(--weight-regular) var(--text-sm)/1.4 var(--font-sans); color: var(--text-tertiary); }
+.support-row__text { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 2px; }
+.support-row__name   { font: var(--weight-semibold) var(--text-lg)/1.25 var(--font-sans); color: var(--text-primary); letter-spacing: -0.01em; }
+.support-row__detail { font: var(--weight-regular) var(--text-base)/1.35 var(--font-sans); color: var(--text-secondary); }
+.support-row:hover .support-row__name,   .support-row:focus-visible .support-row__name   { color: var(--on-accent); }
+.support-row:hover .support-row__detail, .support-row:focus-visible .support-row__detail { color: rgba(255, 255, 255, 0.9); }
+.support-row:hover .keycap, .support-row:focus-visible .keycap {
+  background: rgba(255, 255, 255, 0.22); color: #ffffff;
+  box-shadow: inset 0 0 0 0.5px rgba(255, 255, 255, 0.28);
+}
 
-/* Secondary large button (Ko-fi) — raised + hairline, matches btn-accent--lg height. */
-.btn-line {
-  display: inline-flex; align-items: center; gap: 10px;
-  height: 44px; padding: 0 20px;
-  border-radius: var(--radius-md);
-  background: var(--surface-raised); color: var(--text-primary);
-  font: var(--weight-semibold) var(--text-md)/1 var(--font-sans); letter-spacing: -0.01em;
-  text-decoration: none; cursor: pointer;
-  box-shadow: inset 0 0 0 0.5px var(--border-hairline), var(--shadow-sm);
-  transition: background var(--dur-fast) var(--ease-out), transform var(--dur-instant) var(--ease-out);
-}
-.btn-line:hover { background: var(--fill-hover); }
-.btn-line:active { transform: scale(0.98); }
-.btn-line--lg {
-  height: 54px; padding: 0 26px; gap: 11px;
-  border-radius: 14px; font: var(--weight-semibold) 16px/1 var(--font-sans);
-}
+.support__fine { margin: 24px 0 0; font: var(--weight-regular) var(--text-sm)/1.4 var(--font-sans); color: var(--text-tertiary); }
 
 /* =============================================================================
    FOOTER
@@ -932,9 +932,6 @@ html[data-theme="dark"] .icon-btn .icon-moon { display: inline; }
   #how, #demo, #customize, #github, #support, #faq { padding-left: 20px; padding-right: 20px; }
 
   .support { padding: 40px 22px 36px; }
-  .support__actions { flex-direction: column; align-items: stretch; }
-  .support__actions .btn-accent--lg,
-  .support__actions .btn-line--lg { justify-content: center; }
 
   .hero { padding-left: 20px; padding-right: 20px; }
   .hero__scene { min-height: 300px; padding: 16px; }


### PR DESCRIPTION
## What

Redesigns the site's **Support the project** section. The old layout showed itemized cost tiles — **Apple Developer $99/year**, notarization, development — which read like a price tag or a minimum donation. This replaces them with the donation options rendered as **BrowBro's own picker popover**: the same component the app pops at your cursor.

## Why

The cost tiles framed giving as a transaction with a number attached. The new copy and structure say the opposite — *no tiers, no minimums, any amount helps* — and putting the free "Star the repo" action as a first-class row alongside the paid ones lets the design carry that message without a word of guilt.

## Details

- Three picker rows: **Sponsor on GitHub** (you pick the amount), **Buy me a coffee** (Ko-fi, no account), **Star the repo** (free).
- Hover/focus fills a row with accent blue, matching the real picker's selection state.
- Scoped keyboard nav (↑↓ to move, 1–3 to open) honors the keyboard-first brand.
- FAQ "How can I support BrowBro?" answer updated to drop the running-costs framing.
- Adds `PRODUCT.md` — impeccable project context (brand register + design principles) generated during this work.

## Verification

Screenshotted in Chrome across **light, dark, hover/focus, and 375px mobile** — no horizontal overflow, clean console, tap targets comfortable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)