### PR TITLE
feat(app): add support entry in Settings and the menu-bar dropdown

### DIFF
--- a/Sources/Brand.swift
+++ b/Sources/Brand.swift
@@ -89,6 +89,15 @@ struct AppIconView: View {
     }
 }
 
+// MARK: - Canonical project links
+
+enum BBLinks {
+    static let repo = URL(string: "https://github.com/tiagomoraes/browbro")!
+    static let sponsors = URL(string: "https://github.com/sponsors/tiagomoraes")!
+    static let kofi = URL(string: "https://ko-fi.com/tiagomoraes")!
+    static let supportPage = URL(string: "https://browbro.tiagomoraes.cloud/#support")!
+}
+
 // MARK: - Menu-bar status item glyph
 
 enum BBBrand {

--- a/Sources/MenuDropdownView.swift
+++ b/Sources/MenuDropdownView.swift
@@ -65,6 +65,14 @@ struct MenuDropdownView: View {
                 SettingsWindowController.shared.show()
             }
 
+            MenuRow(title: "Support BrowBro", shortcut: "♥") {
+                closeMenuWindow()
+                // Self-initiated opens route back through BrowBro without a
+                // fresh willBecomeActive; snapshot the z-order here instead.
+                SettingsWindowController.shared.captureOrderSnapshot()
+                NSWorkspace.shared.open(BBLinks.supportPage)
+            }
+
             MenuSeparator()
 
             MenuRow(title: "Quit BrowBro", shortcut: "⌘Q") {

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -28,6 +28,7 @@ struct SettingsView: View {
                     }
                     catalogGroup
                     behaviorGroup
+                    supportGroup
                 }
                 .padding(BB.padPanel)
             }
@@ -195,6 +196,89 @@ struct SettingsView: View {
                             launchAtLogin = LoginItem.isEnabled
                         }))
                 })
+        }
+    }
+    // MARK: Support
+
+    /// The ask, kept quiet and last: three link rows, System-Settings style.
+    /// The free option is a first-class row on purpose — no tiers, no minimums.
+    private var supportGroup: some View {
+        SettingsGroup(title: "Support the project", hint: "any amount helps") {
+            SupportLinkRow(
+                symbol: "heart.fill",
+                tile: Color(red: 0xDB / 255, green: 0x61 / 255, blue: 0xA2 / 255),
+                label: "Sponsor on GitHub",
+                description: "One-time or monthly — you pick the amount.",
+                url: BBLinks.sponsors)
+            BBDivider().padding(.leading, 12)
+            SupportLinkRow(
+                symbol: "cup.and.saucer.fill",
+                tile: Color(red: 0xE8 / 255, green: 0x54 / 255, blue: 0x51 / 255),
+                label: "Buy me a coffee",
+                description: "A one-off on Ko-fi — no account needed.",
+                url: BBLinks.kofi)
+            BBDivider().padding(.leading, 12)
+            SupportLinkRow(
+                symbol: "star.fill",
+                tile: Color(red: 0xEC / 255, green: 0x9A / 255, blue: 0x00 / 255),
+                label: "Star the repo",
+                description: "Free — and it helps just as much.",
+                url: BBLinks.repo)
+        }
+    }
+}
+
+// MARK: - Support link row
+// A whole-row external link: colored icon tile (the System Settings idiom),
+// hover fill, pointer cursor, and a quiet ↗ so it reads as "leaves the app".
+
+private struct SupportLinkRow: View {
+    let symbol: String
+    let tile: Color
+    let label: String
+    let description: String
+    let url: URL
+    @State private var hovered = false
+
+    var body: some View {
+        Button {
+            // The user is working inside Settings; the routed URL must not
+            // demote the window they just clicked in.
+            SettingsWindowController.shared.invalidateOrderSnapshot()
+            NSWorkspace.shared.open(url)
+        } label: {
+            HStack(spacing: 12) {
+                RoundedRectangle(cornerRadius: 6, style: .continuous)
+                    .fill(tile)
+                    .frame(width: 22, height: 22)
+                    .overlay(
+                        Image(systemName: symbol)
+                            .font(.system(size: 11, weight: .semibold))
+                            .foregroundStyle(.white))
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(label)
+                        .font(.system(size: 14, weight: .medium))
+                        .foregroundStyle(BB.textPrimary)
+                    Text(description)
+                        .font(BBFont.rowSub)
+                        .foregroundStyle(BB.textSecondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                Spacer(minLength: 8)
+                Image(systemName: "arrow.up.forward")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(hovered ? BB.textSecondary : BB.textTertiary)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+            .background(hovered ? BB.fillHover : Color.clear)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("\(label) — opens in your browser")
+        .onHover { inside in
+            hovered = inside
+            (inside ? NSCursor.pointingHand : NSCursor.arrow).set()
         }
     }
 }


### PR DESCRIPTION
## What

Gives users an in-app way to support the project, mirroring the site redesign's *any amount helps* framing — no tiers, no price tags.

- **Settings** gains a **Support the project** group (hint: *any amount helps*) at the bottom: three System-Settings-style link rows — **Sponsor on GitHub**, **Buy me a coffee** (Ko-fi), **Star the repo** — with the free option as a first-class row alongside the paid ones. Colored icon tile, hover fill, pointer cursor, and a quiet ↗ marking each as an external link.
- **Menu-bar dropdown** gains a quiet **Support BrowBro ♥** item between Settings… and Quit, opening the site's support section.
- Canonical project URLs centralized in `Brand.swift` (`BBLinks`).

The support link handlers call the z-order snapshot API from #18 so opening a support URL doesn't demote a Settings window the user is working in.

> Supersedes #19, which GitHub auto-closed when its base branch (`fix/settings-window-raise`, #18) was deleted on merge. This re-targets the same commit at `develop`.

## Verification

Built and launched; Settings group and menu item render in both light and dark themes, links open in the default browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)