### PR TITLE
ci: publish the website from main instead of develop

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -2,10 +2,16 @@ name: Deploy website
 
 # Publishes the static site in `site/` to GitHub Pages, served at the custom
 # domain browbro.tiagomoraes.cloud (see site/CNAME).
+#
+# The live site tracks `main` (the released state), so it moves in lockstep
+# with tagged releases rather than day-to-day work on `develop`. The download
+# buttons point at `releases/latest/download/BrowBro.dmg`, which GitHub
+# redirects to the newest release's asset — so the site always offers the
+# latest released build.
 
 on:
   push:
-    branches: [develop]
+    branches: [main]
     paths:
       - "site/**"
       - ".github/workflows/deploy-pages.yml"


### PR DESCRIPTION
## What

Makes the live website track **`main`** (the released state) instead of `develop`.

- Deploy workflow now triggers on pushes to `main` (was `develop`).
- The `github-pages` environment's deployment-branch policy updated to match: **`main`** allowed, `develop` removed (done via API).

## Why

The site should reflect what's actually released, moving in lockstep with tagged releases rather than day-to-day `develop` work.

## Downloads already track the latest release

No change needed there — every download button and the JSON-LD `downloadUrl` already use `releases/latest/download/BrowBro.dmg`, which GitHub redirects to the newest release's asset. So the site always offers the latest released DMG automatically.

## Note on activation

This takes effect once it reaches `main`. Since `main` only advances on release merges, **the redesigned site (and this workflow change) go live with the next release** — when `develop` → `main`. Until then no auto-deploy fires, which is the intended behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)