### PR TITLE
chore: release v0.1.3 — in-app support + Settings window fixes

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,5 @@
+# Renders the "Sponsor" button on the repo.
+# https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository
+
+github: [tiagomoraes]   # https://github.com/sponsors/tiagomoraes
+ko_fi: tiagomoraes      # https://ko-fi.com/tiagomoraes

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -2,10 +2,16 @@ name: Deploy website
 
 # Publishes the static site in `site/` to GitHub Pages, served at the custom
 # domain browbro.tiagomoraes.cloud (see site/CNAME).
+#
+# The live site tracks `main` (the released state), so it moves in lockstep
+# with tagged releases rather than day-to-day work on `develop`. The download
+# buttons point at `releases/latest/download/BrowBro.dmg`, which GitHub
+# redirects to the newest release's asset — so the site always offers the
+# latest released build.
 
 on:
   push:
-    branches: [develop]
+    branches: [main]
     paths:
       - "site/**"
       - ".github/workflows/deploy-pages.yml"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3] - 2026-07-05
+
+### Added
+
+- Support the project from inside the app: a **Support the project** group in Settings
+  (Sponsor on GitHub, Buy me a coffee, Star the repo) and a **Support BrowBro** item in the
+  menu-bar dropdown. Any amount helps — no tiers, no minimums.
+
+### Fixed
+
+- A background Settings window no longer jumps to the front every time a link is routed.
+  Opening a link activates BrowBro (it's the default handler) and the window server would
+  raise its front window; the routed-link path now restores the window to its prior stacking
+  order. The picker is also non-activating now, so the app you clicked the link in keeps focus.
+- Restored the **Settings…** (⌘,) menu command.
+
 ## [0.1.2] - 2026-07-04
 
 ### Changed
@@ -51,7 +67,8 @@ yet notarized, so the first launch needs a manual "Open Anyway" (see the release
 - Marketing website (static, in `site/`) published to GitHub Pages at browbro.tiagomoraes.cloud.
 - Project scaffolding: Gitflow branching model, contribution guidelines, issue/PR templates.
 
-[Unreleased]: https://github.com/tiagomoraes/browbro/compare/v0.1.2...HEAD
+[Unreleased]: https://github.com/tiagomoraes/browbro/compare/v0.1.3...HEAD
+[0.1.3]: https://github.com/tiagomoraes/browbro/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/tiagomoraes/browbro/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/tiagomoraes/browbro/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/tiagomoraes/browbro/releases/tag/v0.1.0

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,53 @@
+# Product
+
+## Register
+
+brand
+
+## Users
+
+macOS users — developers, designers, consultants — who juggle several browsers or Chrome
+profiles and click links all day from Slack, Mail, Messages, and terminals. They arrive at
+the site from a friend's recommendation or a GitHub link, decide within a minute whether to
+download, and care that the app is native, fast, and trustworthy (it takes over the default
+browser, so trust is the whole game).
+
+## Product Purpose
+
+BrowBro is a free, open-source macOS menu-bar app that intercepts clicked links and pops a
+keyboard-first picker at the cursor, so every link opens in the right browser or Chrome
+profile. The site's job: demonstrate that interaction (the live demo IS the pitch), earn
+trust (open source, reversible takeover, local-only routing), and convert to a download or
+`brew install`.
+
+## Brand Personality
+
+Native, playful, trustworthy. Sounds like a helpful friend ("Every link, your call",
+"Buy the bro a coffee"); looks like macOS itself — the site is built from faux Mac windows,
+menu bars, and the app's own popover, pixel-faithful to the app's design tokens.
+
+## Anti-references
+
+- Generic SaaS landing pages: gradient meshes, hero-metric templates, pricing-tier cards.
+- Electron-app marketing that feels web-first rather than Mac-native.
+- Donation pages that guilt or gate: no tiers, no locked features, no "minimum" framing.
+
+## Design Principles
+
+1. **The UI is the illustration.** Features are shown as working facsimiles of the real app
+   (picker, settings window, terminal), never abstract art or static screenshots.
+2. **Pixel-faithful to the app.** The site consumes the app's design tokens verbatim; if it
+   wouldn't fit macOS, it doesn't ship on the site.
+3. **Keyboard-first everywhere.** Interactive demos honor the app's keys (1–9, arrows,
+   Enter, Esc).
+4. **Trust through transparency.** Open source, reversible default-browser takeover, and
+   local-only routing are stated plainly, never buried.
+5. **Asking, never pressuring.** Support is invited with warmth; free actions (starring,
+   sharing) are presented as equals to money.
+
+## Accessibility & Inclusion
+
+- Light and dark themes, honoring the system preference with a manual override.
+- `prefers-reduced-motion` respected across demos and scroll reveals.
+- Full keyboard operability with visible focus (`--focus-ring`).
+- Body text at ≥ 4.5:1 contrast in both themes.

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -20,6 +20,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             forEventClass: kGetURLEventClass,
             andEventID: kGetURLEventID
         )
+        // The window server raises this app's front window when LaunchServices
+        // activates it for a routed link. Snapshot the pre-raise z-order while
+        // it can still be observed; the URL handler restores it.
+        NotificationCenter.default.addObserver(
+            forName: NSApplication.willBecomeActiveNotification, object: nil, queue: .main
+        ) { _ in
+            MainActor.assumeIsolated {
+                SettingsWindowController.shared.captureOrderSnapshot()
+            }
+        }
     }
 
     func applicationDidFinishLaunching(_ notification: Notification) {
@@ -59,6 +69,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func handle(_ url: URL) {
+        // The activation raise has already happened by the time the URL event
+        // arrives; put a background Settings window back where it was.
+        SettingsWindowController.shared.restoreOrderAfterActivationRaise()
         LinkStore.shared.receive(url)
         // Best-effort source attribution: we're a background accessory, so the
         // frontmost app when the link arrives is almost always its sender.

--- a/Sources/Brand.swift
+++ b/Sources/Brand.swift
@@ -89,6 +89,15 @@ struct AppIconView: View {
     }
 }
 
+// MARK: - Canonical project links
+
+enum BBLinks {
+    static let repo = URL(string: "https://github.com/tiagomoraes/browbro")!
+    static let sponsors = URL(string: "https://github.com/sponsors/tiagomoraes")!
+    static let kofi = URL(string: "https://ko-fi.com/tiagomoraes")!
+    static let supportPage = URL(string: "https://browbro.tiagomoraes.cloud/#support")!
+}
+
 // MARK: - Menu-bar status item glyph
 
 enum BBBrand {

--- a/Sources/BrowBroApp.swift
+++ b/Sources/BrowBroApp.swift
@@ -20,5 +20,17 @@ struct BrowBroApp: App {
             Image(nsImage: BBBrand.menuBarIcon())
         }
         .menuBarExtraStyle(.window)
+        .commands {
+            // Re-add the standard "Settings…" item (⌘,) that the removed
+            // Settings scene used to provide, wired to our manually managed
+            // window. Main-menu key equivalents fire whenever BrowBro is the
+            // active app, which is the shortcut the dropdown advertises.
+            CommandGroup(replacing: .appSettings) {
+                Button("Settings…") {
+                    SettingsWindowController.shared.show()
+                }
+                .keyboardShortcut(",", modifiers: .command)
+            }
+        }
     }
 }

--- a/Sources/MenuDropdownView.swift
+++ b/Sources/MenuDropdownView.swift
@@ -65,6 +65,14 @@ struct MenuDropdownView: View {
                 SettingsWindowController.shared.show()
             }
 
+            MenuRow(title: "Support BrowBro", shortcut: "♥") {
+                closeMenuWindow()
+                // Self-initiated opens route back through BrowBro without a
+                // fresh willBecomeActive; snapshot the z-order here instead.
+                SettingsWindowController.shared.captureOrderSnapshot()
+                NSWorkspace.shared.open(BBLinks.supportPage)
+            }
+
             MenuSeparator()
 
             MenuRow(title: "Quit BrowBro", shortcut: "⌘Q") {

--- a/Sources/PickerPanel.swift
+++ b/Sources/PickerPanel.swift
@@ -71,7 +71,11 @@ final class PickerController {
 
         let panel = PickerPanel(
             contentRect: NSRect(origin: .zero, size: size),
-            styleMask: [.borderless],
+            // Non-activating: the panel takes key focus for the keyboard model
+            // without activating the app — activation would raise every other
+            // BrowBro window (a background Settings window) above the picker,
+            // and would steal active status from the link's source app.
+            styleMask: [.borderless, .nonactivatingPanel],
             backing: .buffered,
             defer: false
         )
@@ -86,7 +90,6 @@ final class PickerController {
         position(panel, size: size)
         self.panel = panel
 
-        NSApp.activate(ignoringOtherApps: true)
         panel.makeKeyAndOrderFront(nil)
 
         // Click-away / focus-away dismissal: losing key status (click in another

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -28,6 +28,7 @@ struct SettingsView: View {
                     }
                     catalogGroup
                     behaviorGroup
+                    supportGroup
                 }
                 .padding(BB.padPanel)
             }
@@ -195,6 +196,89 @@ struct SettingsView: View {
                             launchAtLogin = LoginItem.isEnabled
                         }))
                 })
+        }
+    }
+    // MARK: Support
+
+    /// The ask, kept quiet and last: three link rows, System-Settings style.
+    /// The free option is a first-class row on purpose — no tiers, no minimums.
+    private var supportGroup: some View {
+        SettingsGroup(title: "Support the project", hint: "any amount helps") {
+            SupportLinkRow(
+                symbol: "heart.fill",
+                tile: Color(red: 0xDB / 255, green: 0x61 / 255, blue: 0xA2 / 255),
+                label: "Sponsor on GitHub",
+                description: "One-time or monthly — you pick the amount.",
+                url: BBLinks.sponsors)
+            BBDivider().padding(.leading, 12)
+            SupportLinkRow(
+                symbol: "cup.and.saucer.fill",
+                tile: Color(red: 0xE8 / 255, green: 0x54 / 255, blue: 0x51 / 255),
+                label: "Buy me a coffee",
+                description: "A one-off on Ko-fi — no account needed.",
+                url: BBLinks.kofi)
+            BBDivider().padding(.leading, 12)
+            SupportLinkRow(
+                symbol: "star.fill",
+                tile: Color(red: 0xEC / 255, green: 0x9A / 255, blue: 0x00 / 255),
+                label: "Star the repo",
+                description: "Free — and it helps just as much.",
+                url: BBLinks.repo)
+        }
+    }
+}
+
+// MARK: - Support link row
+// A whole-row external link: colored icon tile (the System Settings idiom),
+// hover fill, pointer cursor, and a quiet ↗ so it reads as "leaves the app".
+
+private struct SupportLinkRow: View {
+    let symbol: String
+    let tile: Color
+    let label: String
+    let description: String
+    let url: URL
+    @State private var hovered = false
+
+    var body: some View {
+        Button {
+            // The user is working inside Settings; the routed URL must not
+            // demote the window they just clicked in.
+            SettingsWindowController.shared.invalidateOrderSnapshot()
+            NSWorkspace.shared.open(url)
+        } label: {
+            HStack(spacing: 12) {
+                RoundedRectangle(cornerRadius: 6, style: .continuous)
+                    .fill(tile)
+                    .frame(width: 22, height: 22)
+                    .overlay(
+                        Image(systemName: symbol)
+                            .font(.system(size: 11, weight: .semibold))
+                            .foregroundStyle(.white))
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(label)
+                        .font(.system(size: 14, weight: .medium))
+                        .foregroundStyle(BB.textPrimary)
+                    Text(description)
+                        .font(BBFont.rowSub)
+                        .foregroundStyle(BB.textSecondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                Spacer(minLength: 8)
+                Image(systemName: "arrow.up.forward")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(hovered ? BB.textSecondary : BB.textTertiary)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+            .background(hovered ? BB.fillHover : Color.clear)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("\(label) — opens in your browser")
+        .onHover { inside in
+            hovered = inside
+            (inside ? NSCursor.pointingHand : NSCursor.arrow).set()
         }
     }
 }

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -338,6 +338,7 @@ private struct GripDots: View {
 
 // MARK: - Window controller
 
+
 /// Presents Settings in a manually managed window. Deliberately NOT a SwiftUI
 /// `Settings` scene: for a MenuBarExtra-only app that scene is the app's only
 /// window scene, and macOS sometimes presents it on its own when a clicked
@@ -349,6 +350,54 @@ final class SettingsWindowController: NSObject, NSWindowDelegate {
     private override init() {}
 
     private var window: NSWindow?
+
+    /// The window number (any app's) that sat directly in front of Settings
+    /// the last time this app was about to be activated, plus when. Consumed
+    /// by `restoreOrderAfterActivationRaise`.
+    private var preRaiseNeighbor: (windowNumber: Int?, at: TimeInterval)?
+
+    /// Snapshot the Settings window's place in the global z-order. Call at
+    /// moments that precede a LaunchServices activation raise: the app's
+    /// `willBecomeActive`, and right before the app opens a URL itself.
+    func captureOrderSnapshot() {
+        preRaiseNeighbor = nil
+        guard let window, window.isVisible,
+              let info = CGWindowListCopyWindowInfo([.optionOnScreenOnly], kCGNullWindowID)
+                as? [[String: Any]] else { return }
+        var previous: Int?
+        for w in info {
+            guard (w[kCGWindowLayer as String] as? Int) == 0,
+                  let num = w[kCGWindowNumber as String] as? Int else { continue }
+            if num == window.windowNumber {
+                preRaiseNeighbor = (previous, ProcessInfo.processInfo.systemUptime)
+                return
+            }
+            previous = num
+        }
+    }
+
+    /// Undo the window server's activation raise. When another app opens a
+    /// URL, LaunchServices activates BrowBro and the window server brings its
+    /// front window — a background Settings window — above the sender. That
+    /// raise happens below the NSWindow API (no ordering method is called), so
+    /// it can't be blocked; instead, the URL handler calls this to put the
+    /// window back under the neighbor captured just before activation. A user
+    /// summoning Settings never routes a URL, so legitimate raises stay.
+    func restoreOrderAfterActivationRaise() {
+        guard let window, window.isVisible,
+              let snap = preRaiseNeighbor,
+              ProcessInfo.processInfo.systemUptime - snap.at < 3 else { return }
+        preRaiseNeighbor = nil
+        guard let neighbor = snap.windowNumber else { return }  // was frontmost anyway
+        window.order(.below, relativeTo: neighbor)
+    }
+
+    /// Call when the user deliberately brings Settings forward (summoning it,
+    /// clicking a link row inside it): a pending snapshot must not demote a
+    /// window the user just chose to interact with.
+    func invalidateOrderSnapshot() {
+        preRaiseNeighbor = nil
+    }
 
     func show() {
         if window == nil {
@@ -370,6 +419,7 @@ final class SettingsWindowController: NSObject, NSWindowDelegate {
             self.window = window
         }
         NSApp.activate(ignoringOtherApps: true)
+        invalidateOrderSnapshot()
         window?.makeKeyAndOrderFront(nil)
     }
 

--- a/project.yml
+++ b/project.yml
@@ -7,7 +7,7 @@ options:
 settings:
   base:
     PRODUCT_BUNDLE_IDENTIFIER: so.aca.browbro
-    MARKETING_VERSION: "0.1.2"
+    MARKETING_VERSION: "0.1.3"
     CURRENT_PROJECT_VERSION: "1"
     # Swift 5 language mode keeps the prototype free of strict-concurrency
     # noise; we can tighten to Swift 6 mode once the slice is proven.

--- a/site/app.js
+++ b/site/app.js
@@ -506,6 +506,26 @@
   })();
 
   /* =========================================================================
+     SUPPORT: picker keyboard nav (mirrors the app: arrows move, 1–3 open)
+  ========================================================================= */
+  (function () {
+    var pop = document.querySelector('.support-pick__pop');
+    if (!pop) return;
+    var rows = Array.prototype.slice.call(pop.querySelectorAll('.support-row'));
+    if (!rows.length) return;
+    // Scoped to focus-within so the shortcuts never hijack the rest of the page.
+    pop.addEventListener('keydown', function (e) {
+      var i = rows.indexOf(document.activeElement);
+      if (e.key === 'ArrowDown') { e.preventDefault(); rows[(i + 1) % rows.length].focus(); }
+      else if (e.key === 'ArrowUp') { e.preventDefault(); rows[(i - 1 + rows.length) % rows.length].focus(); }
+      else if (/^[1-9]$/.test(e.key)) {
+        var n = Number(e.key) - 1;
+        if (n < rows.length) { e.preventDefault(); rows[n].click(); }
+      }
+    });
+  })();
+
+  /* =========================================================================
      Footer year + scroll reveal
   ========================================================================= */
   (function () {

--- a/site/app.js
+++ b/site/app.js
@@ -126,6 +126,51 @@
   })();
 
   /* =========================================================================
+     MOBILE NAV MENU
+  ========================================================================= */
+  (function () {
+    var toggle = document.getElementById('nav-toggle');
+    var menu = document.getElementById('nav-menu');
+    if (!toggle || !menu) return;
+
+    function isOpen() { return menu.classList.contains('is-open'); }
+    function setOpen(open) {
+      menu.classList.toggle('is-open', open);
+      toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+      toggle.setAttribute('aria-label', open ? 'Close menu' : 'Open menu');
+    }
+    function close() { setOpen(false); }
+
+    toggle.addEventListener('click', function (e) {
+      e.stopPropagation();
+      setOpen(!isOpen());
+    });
+
+    // Any link tap closes the menu (all links are same-page anchors or GitHub).
+    menu.addEventListener('click', function (e) {
+      if (e.target.closest('a')) close();
+    });
+
+    // Tap outside the menu (and not on the toggle) dismisses it.
+    document.addEventListener('click', function (e) {
+      if (!isOpen()) return;
+      if (menu.contains(e.target) || toggle.contains(e.target)) return;
+      close();
+    });
+
+    document.addEventListener('keydown', function (e) {
+      if (e.key === 'Escape' && isOpen()) { close(); toggle.focus(); }
+    });
+
+    // Leaving the mobile breakpoint should never strand an open overlay.
+    var wide = window.matchMedia('(min-width: 901px)');
+    (wide.addEventListener ? wide.addEventListener.bind(wide, 'change')
+                           : wide.addListener.bind(wide))(function () {
+      if (wide.matches) close();
+    });
+  })();
+
+  /* =========================================================================
      BREW COPY
   ========================================================================= */
   (function () {

--- a/site/index.html
+++ b/site/index.html
@@ -95,7 +95,21 @@
         <svg class="icon-moon" width="17" height="17" viewBox="0 0 24 24" fill="currentColor"><path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z"></path></svg>
       </button>
       <a href="https://github.com/tiagomoraes/browbro/releases/latest/download/BrowBro.dmg" target="_blank" rel="noopener" class="btn-accent">Download</a>
+      <button id="nav-toggle" class="icon-btn nav-burger" aria-label="Open menu" aria-expanded="false" aria-controls="nav-menu">
+        <!-- hamburger (closed) -->
+        <svg class="icon-burger" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M4 7h16M4 12h16M4 17h16"></path></svg>
+        <!-- close (open) -->
+        <svg class="icon-close" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M6 6l12 12M18 6L6 18"></path></svg>
+      </button>
     </div>
+  </div>
+
+  <div id="nav-menu" class="nav-menu">
+    <a href="#how">How it works</a>
+    <a href="#demo">Demo</a>
+    <a href="#customize">Customize</a>
+    <a href="#faq">FAQ</a>
+    <a href="https://github.com/tiagomoraes/browbro" target="_blank" rel="noopener">GitHub</a>
   </div>
 </nav>
 

--- a/site/index.html
+++ b/site/index.html
@@ -332,37 +332,43 @@
 
     <div class="eyebrow">Support the project</div>
     <h2>Buy the bro a coffee.</h2>
-    <p class="support__lede">BrowBro is free, open source, and has no ads or tracking — and it'll stay that way. If it's earned a spot in your menu bar, a small tip helps cover what it costs to keep alive: the Apple Developer account, notarizing every release, and the nights spent building it. Any amount helps.</p>
+    <p class="support__lede">BrowBro is free, open source, and has no ads or tracking — and it'll stay that way. If it's earned its spot in your menu bar, you can help keep it there. No tiers, no minimums, no wrong answer: any amount makes a real difference, and so does a star.</p>
 
-    <div class="support__costs">
-      <div class="cost">
-        <span class="cost__icon"><svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M16.365 1.43c0 1.14-.42 2.2-1.12 2.98-.75.86-1.98 1.52-3.02 1.44-.13-1.1.42-2.28 1.08-3 .74-.82 2.04-1.42 3.06-1.42zM20.5 17.02c-.55 1.27-.81 1.84-1.52 2.96-.99 1.57-2.39 3.52-4.12 3.53-1.54.02-1.94-1-4.03-.99-2.09.01-2.53 1.01-4.07.99-1.73-.01-3.05-1.78-4.04-3.35C-.02 16.76-.31 11.8 1.4 9.17c1.2-1.87 3.1-2.96 4.88-2.96 1.82 0 2.96 1 4.46 1 1.46 0 2.35-1 4.46-1 1.6 0 3.29.87 4.5 2.37-3.95 2.16-3.31 7.8.8 8.44z"></path></svg></span>
-        <span class="cost__label">Apple Developer</span>
-        <span class="cost__val">$99 / year</span>
-      </div>
-      <div class="cost">
-        <span class="cost__icon"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3l7 3v5c0 4.6-3.1 7.6-7 9-3.9-1.4-7-4.4-7-9V6l7-3z"></path><path d="M9 12l2 2 4-4.5"></path></svg></span>
-        <span class="cost__label">Notarization</span>
-        <span class="cost__val">Every release</span>
-      </div>
-      <div class="cost">
-        <span class="cost__icon"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M9 8l-4 4 4 4"></path><path d="M15 8l4 4-4 4"></path></svg></span>
-        <span class="cost__label">Development</span>
-        <span class="cost__val">Nights &amp; weekends</span>
+    <div class="support-pick">
+      <div class="popover support-pick__pop" role="group" aria-label="Ways to support BrowBro">
+        <div class="url-header">
+          <div class="url-header__url"><span class="host">support.browbro</span><span>/any-amount</span></div>
+          <div class="url-header__from"><span>from a happy user</span></div>
+        </div>
+        <div class="popover-divider"></div>
+        <a class="support-row" href="https://github.com/sponsors/tiagomoraes" target="_blank" rel="noopener">
+          <span class="support-row__ico support-row__ico--heart"><svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 21s-6.7-4.35-9.33-8.02C.9 10.27 1.4 6.6 4.2 5.1c2.02-1.08 4.3-.4 5.8 1.28L12 8l2-1.62c1.5-1.68 3.78-2.36 5.8-1.28 2.8 1.5 3.3 5.17 1.53 7.88C18.7 16.65 12 21 12 21z"></path></svg></span>
+          <span class="support-row__text">
+            <span class="support-row__name">Sponsor on GitHub</span>
+            <span class="support-row__detail">One-time or monthly — you pick the amount</span>
+          </span>
+          <span class="keycap" aria-hidden="true">1</span>
+        </a>
+        <a class="support-row" href="https://ko-fi.com/tiagomoraes" target="_blank" rel="noopener">
+          <span class="support-row__ico support-row__ico--coffee"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 8h13v5a5 5 0 0 1-5 5H9a5 5 0 0 1-5-5V8z"></path><path d="M17 9h1.5a2.5 2.5 0 0 1 0 5H17"></path><path d="M8 2.5c-.5.7-.5 1.5 0 2.2M11.5 2.5c-.5.7-.5 1.5 0 2.2"></path></svg></span>
+          <span class="support-row__text">
+            <span class="support-row__name">Buy me a coffee</span>
+            <span class="support-row__detail">A one-off on Ko-fi — no account needed</span>
+          </span>
+          <span class="keycap" aria-hidden="true">2</span>
+        </a>
+        <a class="support-row" href="https://github.com/tiagomoraes/browbro" target="_blank" rel="noopener">
+          <span class="support-row__ico support-row__ico--star"><svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 2.6l2.9 5.88 6.5.94-4.7 4.58 1.11 6.46L12 17.4l-5.81 3.06 1.11-6.46-4.7-4.58 6.5-.94L12 2.6z"></path></svg></span>
+          <span class="support-row__text">
+            <span class="support-row__name">Star the repo</span>
+            <span class="support-row__detail">Free — and it helps more than you'd think</span>
+          </span>
+          <span class="keycap" aria-hidden="true">3</span>
+        </a>
       </div>
     </div>
 
-    <div class="support__actions">
-      <a href="https://github.com/sponsors/tiagomoraes" target="_blank" rel="noopener" class="btn-accent btn-accent--lg">
-        <svg width="19" height="19" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 21s-6.7-4.35-9.33-8.02C.9 10.27 1.4 6.6 4.2 5.1c2.02-1.08 4.3-.4 5.8 1.28L12 8l2-1.62c1.5-1.68 3.78-2.36 5.8-1.28 2.8 1.5 3.3 5.17 1.53 7.88C18.7 16.65 12 21 12 21z"></path></svg>
-        Sponsor on GitHub
-      </a>
-      <a href="https://ko-fi.com/tiagomoraes" target="_blank" rel="noopener" class="btn-line btn-line--lg">
-        <svg width="19" height="19" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 8h13v5a5 5 0 0 1-5 5H9a5 5 0 0 1-5-5V8z"></path><path d="M17 9h1.5a2.5 2.5 0 0 1 0 5H17"></path><path d="M8 2.5c-.5.7-.5 1.5 0 2.2M11.5 2.5c-.5.7-.5 1.5 0 2.2"></path></svg>
-        Buy me a coffee
-      </a>
-    </div>
-    <p class="support__fine">Zero platform fees · one-time or monthly · it all goes to keeping BrowBro alive. Thank you 💙</p>
+    <p class="support__fine">Zero platform fees · every cent goes into keeping BrowBro alive. Thank you 💙</p>
   </div>
 </section>
 
@@ -403,7 +409,7 @@
     </div>
     <div class="faq-item">
       <button class="faq-q" aria-expanded="false"><span class="q">How can I support BrowBro?</span><span class="faq-chevron"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 6l6 6-6 6"></path></svg></span></button>
-      <div class="faq-a">BrowBro is free and always will be. If you'd like to help cover the running costs — the Apple Developer account, notarizing releases, and development time — you can <a href="#support" style="color:var(--accent); text-decoration:none;">sponsor it on GitHub or buy me a coffee</a>. Starring the repo and telling a friend helps just as much.</div>
+      <div class="faq-a">BrowBro is free and always will be. If you'd like to help keep it alive, you can <a href="#support" style="color:var(--accent); text-decoration:none;">sponsor it on GitHub or buy me a coffee</a> — any amount, one-time or monthly. Starring the repo and telling a friend helps just as much.</div>
     </div>
   </div>
 </section>

--- a/site/index.html
+++ b/site/index.html
@@ -83,6 +83,7 @@
       <a href="#how">How it works</a>
       <a href="#demo">Demo</a>
       <a href="#customize">Customize</a>
+      <a href="#support">Support</a>
       <a href="#faq">FAQ</a>
       <a href="https://github.com/tiagomoraes/browbro" target="_blank" rel="noopener">GitHub</a>
     </div>
@@ -108,6 +109,7 @@
     <a href="#how">How it works</a>
     <a href="#demo">Demo</a>
     <a href="#customize">Customize</a>
+    <a href="#support">Support</a>
     <a href="#faq">FAQ</a>
     <a href="https://github.com/tiagomoraes/browbro" target="_blank" rel="noopener">GitHub</a>
   </div>
@@ -323,6 +325,47 @@
   </div>
 </section>
 
+<!-- ============================ SUPPORT ============================ -->
+<section id="support" class="bb-pad">
+  <div class="support bb-reveal">
+    <span class="support__glow" aria-hidden="true"></span>
+
+    <div class="eyebrow">Support the project</div>
+    <h2>Buy the bro a coffee.</h2>
+    <p class="support__lede">BrowBro is free, open source, and has no ads or tracking — and it'll stay that way. If it's earned a spot in your menu bar, a small tip helps cover what it costs to keep alive: the Apple Developer account, notarizing every release, and the nights spent building it. Any amount helps.</p>
+
+    <div class="support__costs">
+      <div class="cost">
+        <span class="cost__icon"><svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M16.365 1.43c0 1.14-.42 2.2-1.12 2.98-.75.86-1.98 1.52-3.02 1.44-.13-1.1.42-2.28 1.08-3 .74-.82 2.04-1.42 3.06-1.42zM20.5 17.02c-.55 1.27-.81 1.84-1.52 2.96-.99 1.57-2.39 3.52-4.12 3.53-1.54.02-1.94-1-4.03-.99-2.09.01-2.53 1.01-4.07.99-1.73-.01-3.05-1.78-4.04-3.35C-.02 16.76-.31 11.8 1.4 9.17c1.2-1.87 3.1-2.96 4.88-2.96 1.82 0 2.96 1 4.46 1 1.46 0 2.35-1 4.46-1 1.6 0 3.29.87 4.5 2.37-3.95 2.16-3.31 7.8.8 8.44z"></path></svg></span>
+        <span class="cost__label">Apple Developer</span>
+        <span class="cost__val">$99 / year</span>
+      </div>
+      <div class="cost">
+        <span class="cost__icon"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3l7 3v5c0 4.6-3.1 7.6-7 9-3.9-1.4-7-4.4-7-9V6l7-3z"></path><path d="M9 12l2 2 4-4.5"></path></svg></span>
+        <span class="cost__label">Notarization</span>
+        <span class="cost__val">Every release</span>
+      </div>
+      <div class="cost">
+        <span class="cost__icon"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M9 8l-4 4 4 4"></path><path d="M15 8l4 4-4 4"></path></svg></span>
+        <span class="cost__label">Development</span>
+        <span class="cost__val">Nights &amp; weekends</span>
+      </div>
+    </div>
+
+    <div class="support__actions">
+      <a href="https://github.com/sponsors/tiagomoraes" target="_blank" rel="noopener" class="btn-accent btn-accent--lg">
+        <svg width="19" height="19" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 21s-6.7-4.35-9.33-8.02C.9 10.27 1.4 6.6 4.2 5.1c2.02-1.08 4.3-.4 5.8 1.28L12 8l2-1.62c1.5-1.68 3.78-2.36 5.8-1.28 2.8 1.5 3.3 5.17 1.53 7.88C18.7 16.65 12 21 12 21z"></path></svg>
+        Sponsor on GitHub
+      </a>
+      <a href="https://ko-fi.com/tiagomoraes" target="_blank" rel="noopener" class="btn-line btn-line--lg">
+        <svg width="19" height="19" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 8h13v5a5 5 0 0 1-5 5H9a5 5 0 0 1-5-5V8z"></path><path d="M17 9h1.5a2.5 2.5 0 0 1 0 5H17"></path><path d="M8 2.5c-.5.7-.5 1.5 0 2.2M11.5 2.5c-.5.7-.5 1.5 0 2.2"></path></svg>
+        Buy me a coffee
+      </a>
+    </div>
+    <p class="support__fine">Zero platform fees · one-time or monthly · it all goes to keeping BrowBro alive. Thank you 💙</p>
+  </div>
+</section>
+
 <!-- ============================ FAQ ============================ -->
 <section id="faq" class="bb-pad">
   <div class="section-head bb-reveal">
@@ -357,6 +400,10 @@
     <div class="faq-item">
       <button class="faq-q" aria-expanded="false"><span class="q">Does BrowBro see my links?</span><span class="faq-chevron"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 6l6 6-6 6"></path></svg></span></button>
       <div class="faq-a">Everything happens locally on your Mac. BrowBro just routes the link to the browser you choose. Nothing leaves your machine.</div>
+    </div>
+    <div class="faq-item">
+      <button class="faq-q" aria-expanded="false"><span class="q">How can I support BrowBro?</span><span class="faq-chevron"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 6l6 6-6 6"></path></svg></span></button>
+      <div class="faq-a">BrowBro is free and always will be. If you'd like to help cover the running costs — the Apple Developer account, notarizing releases, and development time — you can <a href="#support" style="color:var(--accent); text-decoration:none;">sponsor it on GitHub or buy me a coffee</a>. Starring the repo and telling a friend helps just as much.</div>
     </div>
   </div>
 </section>

--- a/site/styles.css
+++ b/site/styles.css
@@ -300,6 +300,9 @@ html[data-theme="dark"] .bb-scene {
 .bb-wrap { max-width: 1120px; margin: 0 auto; }
 .bb-pad  { padding-left: 28px; padding-right: 28px; }
 
+/* Offset in-page anchors so the sticky 60px nav never covers a section head. */
+section[id], #top { scroll-margin-top: 76px; }
+
 .eyebrow {
   font: var(--weight-semibold) var(--text-sm)/1 var(--font-sans);
   letter-spacing: 0.06em;
@@ -789,8 +792,58 @@ html[data-theme="dark"] .icon-btn .icon-moon { display: inline; }
 /* =============================================================================
    RESPONSIVE
    ============================================================================= */
+/* Grid/flex children default to min-width:auto, which refuses to shrink below
+   their content's min-content size and blows out the layout on narrow screens.
+   Letting these tracks/items shrink is what keeps the page free of sideways
+   scroll on mobile. */
+.hero > *,
+.grid-2 > *,
+.grid-3 > *,
+.oss > *,
+.footer__top > *,
+.hero__actions > * { min-width: 0; }
+.btn-brew { min-width: 0; }
+
+/* =============================================================================
+   MOBILE NAV MENU
+   ============================================================================= */
+.nav-burger { display: none; }
+.nav-menu   { display: none; }
+.nav-burger .icon-close { display: none; }
+.nav-burger[aria-expanded="true"] .icon-burger { display: none; }
+.nav-burger[aria-expanded="true"] .icon-close  { display: inline; }
+
 @media (max-width: 900px) {
   .nav__links { display: none; }
+  .nav-burger { display: inline-flex; }
+  .nav-menu {
+    display: block; position: fixed; left: 0; right: 0; top: 60px; z-index: 49;
+    padding: 6px 20px 14px;
+    background: var(--surface-menu);
+    -webkit-backdrop-filter: var(--blur-menu); backdrop-filter: var(--blur-menu);
+    box-shadow: inset 0 -0.5px 0 var(--separator), var(--shadow-md);
+    max-height: calc(100dvh - 60px); overflow-y: auto;
+    opacity: 0; visibility: hidden; transform: translateY(-8px);
+    transition: opacity var(--dur-panel) var(--ease-out),
+                transform var(--dur-panel) var(--ease-out),
+                visibility 0s linear var(--dur-panel);
+  }
+  .nav-menu.is-open {
+    opacity: 1; visibility: visible; transform: none;
+    transition: opacity var(--dur-panel) var(--ease-out),
+                transform var(--dur-panel) var(--ease-out);
+  }
+  .nav-menu a {
+    display: block; padding: 13px 4px; text-decoration: none;
+    color: var(--text-primary);
+    font: var(--weight-medium) var(--text-lg)/1 var(--font-sans);
+    box-shadow: inset 0 -0.5px 0 var(--separator);
+  }
+  .nav-menu a:last-child { box-shadow: none; }
+  .nav-menu a:active { color: var(--accent); }
+}
+
+@media (max-width: 900px) {
   .hero { grid-template-columns: 1fr; padding-top: 40px; gap: 36px; }
   .grid-3 { grid-template-columns: 1fr; }
   .grid-2 { grid-template-columns: 1fr; }
@@ -798,6 +851,21 @@ html[data-theme="dark"] .icon-btn .icon-moon { display: inline; }
   .bb-pad { padding-left: 20px; padding-right: 20px; }
 }
 @media (max-width: 600px) {
+  /* Compact nav so the wordmark, theme, CTA and burger fit down to 320px. */
+  .nav__inner { padding: 0 14px; gap: 8px; }
+  .nav__right { gap: 4px; }
+  .nav__right .btn-accent { padding: 0 12px; }
+  .wordmark { font-size: 20px; }
+
+  /* ID-scoped section padding wins over .bb-pad; bring it down to match. */
+  #how, #demo, #customize, #github, #faq { padding-left: 20px; padding-right: 20px; }
+
+  .hero { padding-left: 20px; padding-right: 20px; }
+  .hero__scene { min-height: 300px; padding: 16px; }
+  .hero__actions { flex-direction: column; align-items: stretch; gap: 12px; }
+  .hero__actions .btn-accent--lg { justify-content: center; }
+  .btn-brew { width: 100%; }
+
   .bb-demo-body { padding: 16px; }
   .bb-demo-anchor { left: 12px; right: 12px; top: 82px; }
   .bb-demo-anchor > .demo-pop { width: auto; }

--- a/site/styles.css
+++ b/site/styles.css
@@ -773,6 +773,77 @@ html[data-theme="dark"] .icon-btn .icon-moon { display: inline; }
 .faq-item.is-open .faq-a { display: block; }
 
 /* =============================================================================
+   SUPPORT / DONATE
+   ============================================================================= */
+#support { padding: 24px 28px 72px; }
+.support {
+  position: relative; overflow: hidden;
+  max-width: 860px; margin: 0 auto;
+  background: var(--surface-raised);
+  border-radius: var(--radius-xl);
+  box-shadow: inset 0 0 0 0.5px var(--border-hairline), var(--shadow-md);
+  padding: 56px 44px 48px;
+  text-align: center;
+}
+/* Soft accent bloom behind the ask; purely decorative. */
+.support__glow {
+  position: absolute; left: 50%; top: -55%;
+  width: 130%; height: 130%; transform: translateX(-50%);
+  background: radial-gradient(50% 50% at 50% 50%, var(--accent-weak) 0%, transparent 70%);
+  pointer-events: none; z-index: 0;
+}
+.support > *:not(.support__glow) { position: relative; z-index: 1; }
+.support h2 {
+  margin: 0 auto; max-width: 20ch;
+  font: var(--weight-bold) clamp(28px, 3.2vw, 40px)/1.08 var(--font-sans);
+  letter-spacing: -0.02em;
+}
+.support__lede {
+  margin: 16px auto 0; max-width: 56ch;
+  font: var(--weight-regular) var(--text-md)/1.6 var(--font-sans);
+  color: var(--text-secondary);
+}
+.support__costs {
+  display: flex; flex-wrap: wrap; justify-content: center; gap: 12px;
+  margin: 32px auto 0; max-width: 600px;
+}
+.cost {
+  flex: 1 1 150px; min-width: 0;
+  display: flex; flex-direction: column; align-items: center; gap: 5px;
+  padding: 18px 14px; border-radius: var(--radius-lg);
+  background: var(--fill-quiet);
+  box-shadow: inset 0 0 0 0.5px var(--border-hairline);
+}
+.cost__icon {
+  width: 38px; height: 38px; margin-bottom: 3px; border-radius: 11px;
+  display: inline-flex; align-items: center; justify-content: center;
+  background: var(--accent-weak); color: var(--accent);
+}
+.cost__label { font: var(--weight-semibold) var(--text-md)/1.2 var(--font-sans); color: var(--text-primary); }
+.cost__val   { font: var(--weight-regular)  var(--text-sm)/1.2 var(--font-sans); color: var(--text-secondary); }
+
+.support__actions { display: flex; flex-wrap: wrap; justify-content: center; gap: 14px; margin-top: 36px; }
+.support__fine { margin: 20px 0 0; font: var(--weight-regular) var(--text-sm)/1.4 var(--font-sans); color: var(--text-tertiary); }
+
+/* Secondary large button (Ko-fi) — raised + hairline, matches btn-accent--lg height. */
+.btn-line {
+  display: inline-flex; align-items: center; gap: 10px;
+  height: 44px; padding: 0 20px;
+  border-radius: var(--radius-md);
+  background: var(--surface-raised); color: var(--text-primary);
+  font: var(--weight-semibold) var(--text-md)/1 var(--font-sans); letter-spacing: -0.01em;
+  text-decoration: none; cursor: pointer;
+  box-shadow: inset 0 0 0 0.5px var(--border-hairline), var(--shadow-sm);
+  transition: background var(--dur-fast) var(--ease-out), transform var(--dur-instant) var(--ease-out);
+}
+.btn-line:hover { background: var(--fill-hover); }
+.btn-line:active { transform: scale(0.98); }
+.btn-line--lg {
+  height: 54px; padding: 0 26px; gap: 11px;
+  border-radius: 14px; font: var(--weight-semibold) 16px/1 var(--font-sans);
+}
+
+/* =============================================================================
    FOOTER
    ============================================================================= */
 .footer { box-shadow: inset 0 0.5px 0 var(--separator); background: var(--surface-raised); }
@@ -858,7 +929,12 @@ html[data-theme="dark"] .icon-btn .icon-moon { display: inline; }
   .wordmark { font-size: 20px; }
 
   /* ID-scoped section padding wins over .bb-pad; bring it down to match. */
-  #how, #demo, #customize, #github, #faq { padding-left: 20px; padding-right: 20px; }
+  #how, #demo, #customize, #github, #support, #faq { padding-left: 20px; padding-right: 20px; }
+
+  .support { padding: 40px 22px 36px; }
+  .support__actions { flex-direction: column; align-items: stretch; }
+  .support__actions .btn-accent--lg,
+  .support__actions .btn-line--lg { justify-content: center; }
 
   .hero { padding-left: 20px; padding-right: 20px; }
   .hero__scene { min-height: 300px; padding: 16px; }

--- a/site/styles.css
+++ b/site/styles.css
@@ -803,45 +803,45 @@ html[data-theme="dark"] .icon-btn .icon-moon { display: inline; }
   font: var(--weight-regular) var(--text-md)/1.6 var(--font-sans);
   color: var(--text-secondary);
 }
-.support__costs {
-  display: flex; flex-wrap: wrap; justify-content: center; gap: 12px;
-  margin: 32px auto 0; max-width: 600px;
+/* The ask, rendered as the product itself: a BrowBro picker whose targets are
+   the ways to help. The free option is a first-class row on purpose — it's the
+   design saying "no minimums" louder than any copy could. */
+.support-pick { margin: 34px auto 0; max-width: 400px; }
+.support-pick__pop { text-align: left; }
+
+.support-row {
+  display: flex; align-items: center; gap: 11px;
+  padding: 9px 10px; border-radius: var(--radius-md);
+  text-decoration: none; cursor: pointer;
+  transition: background var(--dur-instant) var(--ease-out);
 }
-.cost {
-  flex: 1 1 150px; min-width: 0;
-  display: flex; flex-direction: column; align-items: center; gap: 5px;
-  padding: 18px 14px; border-radius: var(--radius-lg);
-  background: var(--fill-quiet);
+/* Hover/focus = the app's selection state: the row fills with accent. */
+.support-row:hover, .support-row:focus-visible { background: var(--accent-fill); outline: none; }
+
+.support-row__ico {
+  flex: none; width: 34px; height: 34px; border-radius: 9px;
+  display: inline-flex; align-items: center; justify-content: center;
   box-shadow: inset 0 0 0 0.5px var(--border-hairline);
 }
-.cost__icon {
-  width: 38px; height: 38px; margin-bottom: 3px; border-radius: 11px;
-  display: inline-flex; align-items: center; justify-content: center;
-  background: var(--accent-weak); color: var(--accent);
-}
-.cost__label { font: var(--weight-semibold) var(--text-md)/1.2 var(--font-sans); color: var(--text-primary); }
-.cost__val   { font: var(--weight-regular)  var(--text-sm)/1.2 var(--font-sans); color: var(--text-secondary); }
+/* Opaque tiles so the colors hold when a row fills with accent, like real app icons. */
+.support-row__ico--heart  { background: #fae3ef; color: #c74e91; }
+.support-row__ico--coffee { background: #ffe6e5; color: #d6403c; }
+.support-row__ico--star   { background: #fcefd2; color: #b57c00; }
+html[data-theme="dark"] .support-row__ico--heart  { background: #432c39; color: #e57fb4; }
+html[data-theme="dark"] .support-row__ico--coffee { background: #442e2d; color: #ff7a77; }
+html[data-theme="dark"] .support-row__ico--star   { background: #443823; color: #f9ab00; }
 
-.support__actions { display: flex; flex-wrap: wrap; justify-content: center; gap: 14px; margin-top: 36px; }
-.support__fine { margin: 20px 0 0; font: var(--weight-regular) var(--text-sm)/1.4 var(--font-sans); color: var(--text-tertiary); }
+.support-row__text { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 2px; }
+.support-row__name   { font: var(--weight-semibold) var(--text-lg)/1.25 var(--font-sans); color: var(--text-primary); letter-spacing: -0.01em; }
+.support-row__detail { font: var(--weight-regular) var(--text-base)/1.35 var(--font-sans); color: var(--text-secondary); }
+.support-row:hover .support-row__name,   .support-row:focus-visible .support-row__name   { color: var(--on-accent); }
+.support-row:hover .support-row__detail, .support-row:focus-visible .support-row__detail { color: rgba(255, 255, 255, 0.9); }
+.support-row:hover .keycap, .support-row:focus-visible .keycap {
+  background: rgba(255, 255, 255, 0.22); color: #ffffff;
+  box-shadow: inset 0 0 0 0.5px rgba(255, 255, 255, 0.28);
+}
 
-/* Secondary large button (Ko-fi) — raised + hairline, matches btn-accent--lg height. */
-.btn-line {
-  display: inline-flex; align-items: center; gap: 10px;
-  height: 44px; padding: 0 20px;
-  border-radius: var(--radius-md);
-  background: var(--surface-raised); color: var(--text-primary);
-  font: var(--weight-semibold) var(--text-md)/1 var(--font-sans); letter-spacing: -0.01em;
-  text-decoration: none; cursor: pointer;
-  box-shadow: inset 0 0 0 0.5px var(--border-hairline), var(--shadow-sm);
-  transition: background var(--dur-fast) var(--ease-out), transform var(--dur-instant) var(--ease-out);
-}
-.btn-line:hover { background: var(--fill-hover); }
-.btn-line:active { transform: scale(0.98); }
-.btn-line--lg {
-  height: 54px; padding: 0 26px; gap: 11px;
-  border-radius: 14px; font: var(--weight-semibold) 16px/1 var(--font-sans);
-}
+.support__fine { margin: 24px 0 0; font: var(--weight-regular) var(--text-sm)/1.4 var(--font-sans); color: var(--text-tertiary); }
 
 /* =============================================================================
    FOOTER
@@ -932,9 +932,6 @@ html[data-theme="dark"] .icon-btn .icon-moon { display: inline; }
   #how, #demo, #customize, #github, #support, #faq { padding-left: 20px; padding-right: 20px; }
 
   .support { padding: 40px 22px 36px; }
-  .support__actions { flex-direction: column; align-items: stretch; }
-  .support__actions .btn-accent--lg,
-  .support__actions .btn-line--lg { justify-content: center; }
 
   .hero { padding-left: 20px; padding-right: 20px; }
   .hero__scene { min-height: 300px; padding: 16px; }


### PR DESCRIPTION
Release **v0.1.3**. Merges the work accumulated on `develop` since v0.1.2 into `main`.

## App changes (first real app changes since 0.1.0)

### Added
- **In-app support entry**: a *Support the project* group in Settings (Sponsor on GitHub, Buy me a coffee, Star the repo) and a *Support BrowBro* item in the menu-bar dropdown. Any amount helps — no tiers, no minimums.

### Fixed
- A **background Settings window no longer jumps to the front** every time a link is routed. Opening a link activates BrowBro (it's the default handler) and the window server would raise its front window; the routed-link path now restores the window's prior stacking order. The picker is also non-activating now, so the app you clicked the link in keeps focus.
- Restored the **Settings… (⌘,)** menu command.

## Also rides along
- Marketing site: support section redesigned as a BrowBro picker (removes the "$99/year" cost tiles), donation section, mobile responsiveness.
- CI: the website now deploys from `main`. **Merging this PR publishes the redesigned site** via the Pages workflow.

## Release checklist (maintainer)

- [ ] Merge this PR to `main`
- [ ] Build + notarize the DMG (`packaging/notarize/notarize-release.sh`, see `docs/NOTARIZING.md`)
- [ ] Tag `v0.1.3` and push the tag
- [ ] Create the GitHub release and upload `BrowBro.dmg` (the site's `releases/latest/download/BrowBro.dmg` links resolve to it automatically)
- [ ] Confirm the Pages deploy from `main` succeeded and the redesigned site is live

## Verification so far
- App builds clean; `MARKETING_VERSION` → `0.1.3`.
- The window-raise fix was diagnosed and confirmed with a scripted z-order repro.
- Site verified in Chrome across light/dark/mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)