### PR TITLE
chore: release v0.1.4 — in-app updates (Sparkle) + Settings version indicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4] - 2026-07-05
+
+### Added
+
+- **In-app updates.** BrowBro now updates itself (via [Sparkle](https://sparkle-project.org)),
+  so DMG and Homebrew installs no longer need a manual re-download. **Settings → Updates** has a
+  **Check Now** button and an **Automatically check for updates** toggle, and the menu-bar
+  dropdown gains a **Check for Updates…** item. Updates are verified with an EdDSA signature and
+  installed in place — and, unlike a manual download, they skip the first-run "Open Anyway"
+  prompt. See [docs/UPDATES.md](docs/UPDATES.md).
+- A **version indicator** in Settings: the current version and build show at the bottom of the
+  window ("BrowBro 0.1.4 (4)").
+
 ## [0.1.3] - 2026-07-05
 
 ### Added
@@ -67,7 +80,8 @@ yet notarized, so the first launch needs a manual "Open Anyway" (see the release
 - Marketing website (static, in `site/`) published to GitHub Pages at browbro.tiagomoraes.cloud.
 - Project scaffolding: Gitflow branching model, contribution guidelines, issue/PR templates.
 
-[Unreleased]: https://github.com/tiagomoraes/browbro/compare/v0.1.3...HEAD
+[Unreleased]: https://github.com/tiagomoraes/browbro/compare/v0.1.4...HEAD
+[0.1.4]: https://github.com/tiagomoraes/browbro/compare/v0.1.3...v0.1.4
 [0.1.3]: https://github.com/tiagomoraes/browbro/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/tiagomoraes/browbro/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/tiagomoraes/browbro/compare/v0.1.0...v0.1.1

--- a/README.md
+++ b/README.md
@@ -18,6 +18,16 @@ BrowBro is not yet notarized, so macOS blocks it on first launch. To open it: go
 **System Settings > Privacy & Security** and click **Open Anyway** (or run
 `xattr -dr com.apple.quarantine "/Applications/BrowBro.app"`).
 
+## Updating
+
+BrowBro updates itself. From **Settings → Updates** you can hit **Check Now** or leave
+**Automatically check for updates** on, and the menu-bar dropdown has a **Check for
+Updates…** item too. Updates (powered by [Sparkle](https://sparkle-project.org)) are
+signature-verified and installed in place — and, unlike the initial download, they don't
+trip the first-launch "Open Anyway" prompt. Homebrew users can also just
+`brew upgrade --cask browbro`. See [docs/UPDATES.md](docs/UPDATES.md) for how releases are
+signed and published.
+
 ## Website
 
 The marketing site lives in [`site/`](site/): a self-contained static site (no build

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -23,6 +23,19 @@
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 
+	<!-- Sparkle in-app updates. The feed lists released builds; each update
+	     archive is verified against SUPublicEDKey below (EdDSA), so trust does
+	     not depend on Apple notarization. See docs/UPDATES.md. -->
+	<key>SUFeedURL</key>
+	<string>https://browbro.tiagomoraes.cloud/appcast.xml</string>
+	<key>SUPublicEDKey</key>
+	<string>WYtqTgJc2C4c4UUZvfj/wa2qpCi11K584cjDcVf+gwU=</string>
+	<!-- Turn automatic update checks on by default (and skip Sparkle's
+	     first-launch permission prompt). The Settings toggle can turn them off;
+	     "Check for Updates…" always works regardless. -->
+	<key>SUEnableAutomaticChecks</key>
+	<true/>
+
 	<!-- App icon: white unibrow mark on a BrowBro-blue squircle
 	     (regenerate via scripts/generate-appicon.swift). -->
 	<key>CFBundleIconFile</key>

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -33,6 +33,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationDidFinishLaunching(_ notification: Notification) {
+        // Start Sparkle so scheduled update checks run in the background (the
+        // Settings toggle and menu item drive on-demand checks). Referencing the
+        // singleton is what constructs and starts the updater.
+        _ = UpdaterController.shared
+
         // Guided first run: transparent, reversible default-browser takeover.
         if !Preferences.hasCompletedOnboarding {
             OnboardingController.shared.show()

--- a/Sources/MenuDropdownView.swift
+++ b/Sources/MenuDropdownView.swift
@@ -65,6 +65,11 @@ struct MenuDropdownView: View {
                 SettingsWindowController.shared.show()
             }
 
+            MenuRow(title: "Check for Updates…") {
+                closeMenuWindow()
+                UpdaterController.shared.checkForUpdates()
+            }
+
             MenuRow(title: "Support BrowBro", shortcut: "♥") {
                 closeMenuWindow()
                 // Self-initiated opens route back through BrowBro without a

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -6,6 +6,7 @@ import UniformTypeIdentifiers
 /// access, the picker catalog (reorder + show/hide), and behavior toggles.
 struct SettingsView: View {
     @State private var catalog = TargetCatalog.shared
+    @State private var updater = UpdaterController.shared
     @State private var isDefault = DefaultBrowser.isBrowBro
     @State private var chromeAccess = false
     @State private var working = false
@@ -28,7 +29,9 @@ struct SettingsView: View {
                     }
                     catalogGroup
                     behaviorGroup
+                    updatesGroup
                     supportGroup
+                    versionFooter
                 }
                 .padding(BB.padPanel)
             }
@@ -198,6 +201,55 @@ struct SettingsView: View {
                 })
         }
     }
+
+    // MARK: Updates
+
+    private var updatesGroup: some View {
+        SettingsGroup(title: "Updates") {
+            SettingsRow(
+                leading: {
+                    Image(systemName: "arrow.triangle.2.circlepath")
+                        .font(.system(size: 15, weight: .medium))
+                        .foregroundStyle(BB.iconSecondary)
+                },
+                label: "Check for updates",
+                description: "BrowBro installs updates in place — no reinstall, no drag to Applications.",
+                trailing: {
+                    Button("Check Now") { updater.checkForUpdates() }
+                        .buttonStyle(BBButtonStyle(variant: .secondary, size: .sm))
+                        .disabled(!updater.canCheckForUpdates)
+                })
+            BBDivider().padding(.leading, 12)
+            SettingsRow(
+                label: "Automatically check for updates",
+                description: "Check in the background and let me know when a new version is ready.",
+                trailing: {
+                    BBSwitch(isOn: Binding(
+                        get: { updater.automaticallyChecksForUpdates },
+                        set: { updater.automaticallyChecksForUpdates = $0 }))
+                })
+        }
+    }
+
+    // MARK: Version footer
+
+    /// The at-a-glance "which build am I on" line, kept quiet at the very bottom.
+    private var versionFooter: some View {
+        Text(Self.versionString)
+            .font(BBFont.caption)
+            .foregroundStyle(BB.textQuaternary)
+            .frame(maxWidth: .infinity)
+            .padding(.top, 2)
+    }
+
+    /// "BrowBro 0.1.4 (4)" — short version with the build number in parentheses.
+    static var versionString: String {
+        let info = Bundle.main.infoDictionary
+        let short = info?["CFBundleShortVersionString"] as? String ?? "—"
+        let build = info?["CFBundleVersion"] as? String ?? "—"
+        return "BrowBro \(short) (\(build))"
+    }
+
     // MARK: Support
 
     /// The ask, kept quiet and last: three link rows, System-Settings style.

--- a/Sources/Updater.swift
+++ b/Sources/Updater.swift
@@ -1,0 +1,62 @@
+import AppKit
+import Observation
+import Sparkle
+
+/// Owns Sparkle's updater and exposes a small, SwiftUI-friendly surface for the
+/// "Check for Updates…" affordances in Settings and the menu-bar dropdown.
+///
+/// BrowBro ships outside the App Store (DMG + Homebrew cask), so it can't rely
+/// on the App Store to deliver updates. Sparkle is the standard for this: it
+/// checks a signed appcast, and — when the user accepts — downloads, verifies,
+/// and installs the new build in place, then relaunches. Trust is anchored on
+/// the EdDSA public key in Info.plist (`SUPublicEDKey`), independent of Apple
+/// notarization; Sparkle-installed updates also skip the Gatekeeper quarantine
+/// prompt the first manual download shows. See docs/UPDATES.md.
+@MainActor
+@Observable
+final class UpdaterController {
+    static let shared = UpdaterController()
+
+    /// Sparkle's standard controller. `startingUpdater: true` kicks off the
+    /// scheduled background checks; it also owns the standard update UI (the
+    /// window with release notes and the Install button).
+    @ObservationIgnored
+    private let controller: SPUStandardUpdaterController
+
+    /// Mirrors `SPUUpdater.canCheckForUpdates` so the button can disable itself
+    /// while a check is already in flight.
+    private(set) var canCheckForUpdates = false
+
+    /// Whether Sparkle checks for updates on its own schedule. Bound to the
+    /// Settings toggle; Sparkle persists the choice in the app's UserDefaults.
+    var automaticallyChecksForUpdates: Bool {
+        didSet {
+            controller.updater.automaticallyChecksForUpdates = automaticallyChecksForUpdates
+        }
+    }
+
+    @ObservationIgnored
+    private var canCheckObservation: NSKeyValueObservation?
+
+    private init() {
+        controller = SPUStandardUpdaterController(
+            startingUpdater: true, updaterDelegate: nil, userDriverDelegate: nil)
+        automaticallyChecksForUpdates = controller.updater.automaticallyChecksForUpdates
+        canCheckForUpdates = controller.updater.canCheckForUpdates
+        canCheckObservation = controller.updater.observe(
+            \.canCheckForUpdates, options: [.initial, .new]
+        ) { [weak self] updater, _ in
+            MainActor.assumeIsolated {
+                self?.canCheckForUpdates = updater.canCheckForUpdates
+            }
+        }
+    }
+
+    /// Show Sparkle's update dialog. Brings the app forward first: BrowBro is an
+    /// `LSUIElement` accessory, so without activation the update window could
+    /// open behind whatever the user is looking at.
+    func checkForUpdates() {
+        NSApp.activate(ignoringOtherApps: true)
+        controller.checkForUpdates(nil)
+    }
+}

--- a/docs/NOTARIZING.md
+++ b/docs/NOTARIZING.md
@@ -44,13 +44,19 @@ spctl -a -t open --context context:primary-signature -vv build/BrowBro.dmg   # -
 
 ## Release it
 
-1. Bump `MARKETING_VERSION` in `project.yml`, update `CHANGELOG.md`.
+1. Bump `MARKETING_VERSION` **and** `CURRENT_PROJECT_VERSION` in `project.yml`
+   (the build number must strictly increase for Sparkle — see
+   [UPDATES.md](UPDATES.md)), and update `CHANGELOG.md`.
 2. Cut `release/x.y.z`, PR into `main`, tag `vX.Y.Z` (see CONTRIBUTING.md).
 3. Upload the notarized **`BrowBro.dmg`** as the release asset (keep the exact
    name so `releases/latest/download/BrowBro.dmg` and the website keep working).
-4. Update the cask in the [homebrew-browbro tap](https://github.com/tiagomoraes/homebrew-browbro):
+4. Publish the Sparkle update feed so existing installs can self-update: run
+   `packaging/appcast/generate-item.sh build/BrowBro.dmg`, paste the printed
+   `<item>` at the top of the `<channel>` in `site/appcast.xml`, and merge it to
+   `main` (Pages redeploys the feed). Full walkthrough in [UPDATES.md](UPDATES.md).
+5. Update the cask in the [homebrew-browbro tap](https://github.com/tiagomoraes/homebrew-browbro):
    bump `version` and `sha256`.
-5. Once notarized and reasonably popular, the cask can be submitted to
+6. Once notarized and reasonably popular, the cask can be submitted to
    homebrew-cask core so the bare `brew install --cask browbro` works.
 
 ## Notes

--- a/docs/UPDATES.md
+++ b/docs/UPDATES.md
@@ -1,0 +1,64 @@
+# In-app updates (Sparkle)
+
+BrowBro ships outside the App Store (DMG + Homebrew cask), so it updates itself
+with [Sparkle](https://sparkle-project.org) — the standard framework for
+non-App-Store macOS apps. From **Settings → Updates** (or the menu-bar
+**Check for Updates…** item) BrowBro checks a signed feed, and when a newer build
+exists it downloads, verifies, and installs it in place, then relaunches. No
+re-download, no drag-to-Applications.
+
+## How trust works (no notarization required)
+
+Each update archive is signed with an **EdDSA (ed25519)** key. The matching
+public key is embedded in the app (`SUPublicEDKey` in `Resources/Info.plist`);
+Sparkle refuses any update whose signature doesn't verify against it. This is
+independent of Apple notarization — so BrowBro's unsigned-to-the-world DMG can
+still deliver trustworthy updates. As a bonus, Sparkle-installed updates are not
+quarantined, so they launch **without** the first-run "Open Anyway" detour that a
+manual DMG download triggers.
+
+- **Feed:** `https://browbro.tiagomoraes.cloud/appcast.xml` (served by GitHub
+  Pages from [`site/appcast.xml`](../site/appcast.xml)).
+- **Public key:** `WYtqTgJc2C4c4UUZvfj/wa2qpCi11K584cjDcVf+gwU=`
+- **Private key:** stored in the maintainer's **login keychain** (generated once
+  with Sparkle's `generate_keys`). It is **never** committed. Losing it means a
+  new key pair — and every already-installed copy stops trusting updates until
+  users manually install a build carrying the new public key. **Back it up:**
+  ```sh
+  ./bin/generate_keys -x sparkle_private_key.txt   # then store it somewhere safe & delete the file
+  ```
+  (`generate_keys`/`sign_update` live under
+  `build/SourcePackages/artifacts/sparkle/Sparkle/bin/` after
+  `xcodebuild -resolvePackageDependencies`.)
+
+## Cutting a release with an update
+
+Sparkle decides "is this newer?" by comparing **`CFBundleVersion`**
+(`CURRENT_PROJECT_VERSION` in `project.yml`). It **must strictly increase** on
+every public release, or clients won't see the update.
+
+1. Bump both `MARKETING_VERSION` (e.g. `0.1.5`) and `CURRENT_PROJECT_VERSION`
+   (e.g. `5`) in `project.yml`, and move the `CHANGELOG.md` entries under a new
+   heading. (Follow the normal release flow in [CONTRIBUTING.md](../CONTRIBUTING.md).)
+2. Build the release DMG — `packaging/dmg/build-dmg.sh build/BrowBro.dmg`
+   (or the notarized `packaging/notarize/notarize-release.sh` once a Developer ID
+   cert exists; see [NOTARIZING.md](NOTARIZING.md)).
+3. Generate the appcast `<item>` and paste it at the top of the `<channel>` in
+   `site/appcast.xml`:
+   ```sh
+   packaging/appcast/generate-item.sh build/BrowBro.dmg
+   ```
+   The script signs the DMG with the keychain private key and prints a ready
+   `<item>` (version, download URL, size, EdDSA signature, release notes from
+   `CHANGELOG.md`).
+4. Create the GitHub release `vX.Y.Z` and upload the DMG as **`BrowBro.dmg`**
+   (the exact name the appcast URL and the website expect).
+5. Merge `site/appcast.xml` to `main` so GitHub Pages publishes the new feed.
+6. Bump the Homebrew cask (see [NOTARIZING.md](NOTARIZING.md) → "Release it").
+
+Existing installs then pick up the update on their next scheduled check (or when
+the user hits **Check Now**).
+
+> Sparkle updates only work for builds that already contain Sparkle, i.e. `0.1.4`
+> and later. Users on `0.1.3` or earlier must install `0.1.4+` manually once;
+> after that, updates are automatic.

--- a/packaging/appcast/generate-item.sh
+++ b/packaging/appcast/generate-item.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+#
+# Print a Sparkle appcast <item> for a built BrowBro DMG, ready to paste at the
+# top of the <channel> in site/appcast.xml. Signs the DMG with the EdDSA private
+# key from your login keychain (see docs/UPDATES.md).
+#
+# Usage:
+#   packaging/appcast/generate-item.sh build/BrowBro.dmg
+#
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+DMG="${1:-build/BrowBro.dmg}"
+[ -f "$DMG" ] || { echo "error: DMG not found: $DMG" >&2; exit 1; }
+
+SIGN_UPDATE="build/SourcePackages/artifacts/sparkle/Sparkle/bin/sign_update"
+if [ ! -x "$SIGN_UPDATE" ]; then
+  echo "error: sign_update not found. Run first:" >&2
+  echo "  xcodebuild -project BrowBro.xcodeproj -scheme BrowBro -resolvePackageDependencies -derivedDataPath build" >&2
+  exit 1
+fi
+
+# Versions come from the single source of truth, project.yml.
+SHORT=$(awk -F'"' '/MARKETING_VERSION:/{print $2; exit}' project.yml)
+BUILD=$(awk -F'"' '/CURRENT_PROJECT_VERSION:/{print $2; exit}' project.yml)
+URL="https://github.com/tiagomoraes/browbro/releases/download/v${SHORT}/BrowBro.dmg"
+PUBDATE=$(LC_ALL=C date -u '+%a, %d %b %Y %H:%M:%S +0000')
+
+# sign_update prints:  sparkle:edSignature="…" length="…"
+SIG_ATTRS=$("$SIGN_UPDATE" "$DMG")
+
+# Release notes: the CHANGELOG section for this version, rendered to simple HTML.
+# Matches the "## [x.y.z]" heading literally (index, not regex — the dots in a
+# version would otherwise be wildcards), reflows wrapped bullet lines, then turns
+# **bold** and [text](url) into HTML.
+NOTES=$(awk -v head="## [$SHORT]" '
+  index($0, head) == 1 { grab = 1; next }
+  grab && /^## \[/ { exit }
+  grab { print }
+' CHANGELOG.md | awk '
+  function flush() { if (item != "") { print "<li>" item "</li>"; item = "" } }
+  /^### / { flush(); if (ul) { print "</ul>"; ul = 0 }
+            h = $0; sub(/^### /, "", h); print "<h4>" h "</h4>"; next }
+  /^- /   { flush(); if (!ul) { print "<ul>"; ul = 1 }
+            item = $0; sub(/^- /, "", item); next }
+  /^[[:space:]]*$/ { next }
+  { line = $0; sub(/^[[:space:]]+/, "", line); item = item " " line }   # wrapped line
+  END { flush(); if (ul) print "</ul>" }
+' | sed -E \
+    -e 's/\*\*([^*]+)\*\*/<strong>\1<\/strong>/g' \
+    -e 's/\[([^]]+)\]\(([^)]+)\)/<a href="\2">\1<\/a>/g')
+
+cat <<EOF
+    <item>
+      <title>Version ${SHORT}</title>
+      <link>https://github.com/tiagomoraes/browbro/releases/tag/v${SHORT}</link>
+      <sparkle:version>${BUILD}</sparkle:version>
+      <sparkle:shortVersionString>${SHORT}</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
+      <pubDate>${PUBDATE}</pubDate>
+      <description><![CDATA[
+${NOTES}
+      ]]></description>
+      <enclosure url="${URL}"
+                 ${SIG_ATTRS}
+                 type="application/x-apple-diskimage" />
+    </item>
+EOF

--- a/packaging/notarize/notarize-release.sh
+++ b/packaging/notarize/notarize-release.sh
@@ -38,6 +38,23 @@ xcodebuild -project BrowBro.xcodeproj -scheme BrowBro -configuration Release \
 APP="$DD/Build/Products/Release/BrowBro.app"
 
 echo "▶ Re-signing with hardened runtime + secure timestamp…"
+# Sparkle ships nested helpers (an updater app + XPC services). They must be
+# signed inside-out with the same Developer ID and hardened runtime, or
+# notarization rejects them. `--deep` does NOT sign these correctly (Sparkle
+# advises against it), so sign each explicitly, innermost first, then the app.
+SPARKLE="$APP/Contents/Frameworks/Sparkle.framework"
+if [ -d "$SPARKLE" ]; then
+  SPARKLE_VERSION="$SPARKLE/Versions/Current"
+  for nested in \
+    "$SPARKLE_VERSION/XPCServices/Downloader.xpc" \
+    "$SPARKLE_VERSION/XPCServices/Installer.xpc" \
+    "$SPARKLE_VERSION/Autoupdate" \
+    "$SPARKLE_VERSION/Updater.app" \
+    "$SPARKLE"; do
+    [ -e "$nested" ] && codesign --force --options runtime --timestamp \
+      --sign "$DEVELOPER_ID" "$nested"
+  done
+fi
 codesign --force --options runtime --timestamp \
   --entitlements "$ENTITLEMENTS" --sign "$DEVELOPER_ID" "$APP"
 codesign --verify --strict --deep "$APP"

--- a/project.yml
+++ b/project.yml
@@ -4,11 +4,20 @@ options:
   deploymentTarget:
     macOS: "14.0"
   createIntermediateGroups: true
+packages:
+  # In-app updates for the DMG/Homebrew build (Sparkle is the standard for
+  # non-App-Store macOS apps). Trust is anchored on an EdDSA signature over each
+  # update archive, independent of Apple notarization — see docs/UPDATES.md.
+  Sparkle:
+    url: https://github.com/sparkle-project/Sparkle
+    from: "2.5.0"
 settings:
   base:
     PRODUCT_BUNDLE_IDENTIFIER: so.aca.browbro
-    MARKETING_VERSION: "0.1.3"
-    CURRENT_PROJECT_VERSION: "1"
+    MARKETING_VERSION: "0.1.4"
+    # CFBundleVersion. Sparkle compares this to decide if an update is newer, so
+    # it MUST increase on every public release (see docs/UPDATES.md).
+    CURRENT_PROJECT_VERSION: "4"
     # Swift 5 language mode keeps the prototype free of strict-concurrency
     # noise; we can tighten to Swift 6 mode once the slice is proven.
     SWIFT_VERSION: "5.0"
@@ -32,6 +41,8 @@ targets:
       - Sources
       - path: Resources/AppIcon.icns
         buildPhase: resources
+    dependencies:
+      - package: Sparkle
     settings:
       base:
         GENERATE_INFOPLIST_FILE: "NO"

--- a/site/appcast.xml
+++ b/site/appcast.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <channel>
+    <title>BrowBro</title>
+    <link>https://browbro.tiagomoraes.cloud/appcast.xml</link>
+    <description>In-app update feed for BrowBro. Each item is EdDSA-signed; see docs/UPDATES.md.</description>
+    <language>en</language>
+    <item>
+      <title>Version 0.1.4</title>
+      <link>https://github.com/tiagomoraes/browbro/releases/tag/v0.1.4</link>
+      <sparkle:version>4</sparkle:version>
+      <sparkle:shortVersionString>0.1.4</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
+      <pubDate>Sun, 05 Jul 2026 05:39:20 +0000</pubDate>
+      <description><![CDATA[
+<h4>Added</h4>
+<ul>
+<li><strong>In-app updates.</strong> BrowBro now updates itself (via <a href="https://sparkle-project.org">Sparkle</a>), so DMG and Homebrew installs no longer need a manual re-download. <strong>Settings → Updates</strong> has a <strong>Check Now</strong> button and an <strong>Automatically check for updates</strong> toggle, and the menu-bar dropdown gains a <strong>Check for Updates…</strong> item. Updates are verified with an EdDSA signature and installed in place — and, unlike a manual download, they skip the first-run "Open Anyway" prompt. See <a href="docs/UPDATES.md">docs/UPDATES.md</a>.</li>
+<li>A <strong>version indicator</strong> in Settings: the current version and build show at the bottom of the window ("BrowBro 0.1.4 (4)").</li>
+</ul>
+      ]]></description>
+      <enclosure url="https://github.com/tiagomoraes/browbro/releases/download/v0.1.4/BrowBro.dmg"
+                 sparkle:edSignature="3CzJoP19iKfhiOEXfXhGzACVKTLPPtjWI9vdJbhIVEwXHOnFctmrQ/NBZ2Iw7p6uDEaOIw5RA5spGPmFfipaDQ==" length="2597054"
+                 type="application/x-apple-diskimage" />
+    </item>
+  </channel>
+</rss>


### PR DESCRIPTION
Release **v0.1.4**. Cut from `develop` (see #24).

## Highlights

- **In-app updates via [Sparkle](https://sparkle-project.org)** — DMG/Homebrew installs self-update. Settings → Updates has **Check Now** + an **Automatically check for updates** toggle; the menu-bar dropdown gains **Check for Updates…**. Updates are EdDSA-signed (`SUPublicEDKey`), install in place, and skip the first-run "Open Anyway" prompt.
- **Version indicator** in Settings (`BrowBro 0.1.4 (4)`).

## Release steps (post-merge)

1. Tag `v0.1.4` on the merge commit and push.
2. Publish the GitHub Release with the universal `BrowBro.dmg` (the exact bytes signed in `site/appcast.xml`).
3. Merging this PR deploys the Sparkle feed (`site/appcast.xml`) via GitHub Pages.
4. Bump the Homebrew cask (`version` + `sha256`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)