### PR TITLE
feat: hold a key to pick — gate the picker behind a modifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Hold a key to pick.** A new **Settings → Behavior** option, "Ask only when I hold a key",
+  makes a plain click open your default browser straight away and only pops the picker when you
+  hold a modifier while clicking. Choose the trigger key (⌘ / ⌥ / ⌃ / ⇧, default ⌥) and which
+  browser plain clicks open in. The picker's always-on behavior is unchanged when the option
+  is off.
+
 ## [0.1.4] - 2026-07-05
 
 ### Added

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -46,8 +46,11 @@ or which **Chrome profile** — opens it. Open-source, in the spirit of Velja.
 ## Out of scope → milestone 2+
 
 Rules engine · "always use X for this site" · URL transforms (unshorten / strip tracking) ·
-routing to native apps (Zoom/Slack deep links) · hold-modifier-to-bypass ·
+routing to native apps (Zoom/Slack deep links) ·
 other Chromium browsers' profiles · Arc / Firefox.
+
+_(Shipped: hold-a-key-to-pick — the picker can be gated behind a modifier, with a plain click
+opening a chosen default. See Settings → Behavior.)_
 
 ## Recommended build order (de-risk first)
 

--- a/Sources/PickerPanel.swift
+++ b/Sources/PickerPanel.swift
@@ -38,6 +38,17 @@ final class PickerController {
             return
         }
 
+        // Modifier mode: a plain click opens the chosen default directly; the
+        // picker only appears while the trigger key is held (read now, moments
+        // after the click). A hidden target can still be the default, so resolve
+        // against the full catalog before falling back to the top of the list.
+        if Preferences.requireModifierForPicker && !Preferences.triggerModifier.isHeld {
+            let target = catalog.all.first { $0.id == Preferences.defaultTargetID } ?? targets[0]
+            pickerLog.info("modifier mode, key not held; opening \(target.name, privacy: .public)")
+            launch(target, url: url)
+            return
+        }
+
         // If only one target is shown, just open it (Settings: skip picker).
         if targets.count == 1 && Preferences.skipSingle {
             launch(targets[0], url: url)

--- a/Sources/Preferences.swift
+++ b/Sources/Preferences.swift
@@ -1,5 +1,47 @@
+import AppKit
 import Foundation
 import ServiceManagement
+
+/// A keyboard modifier the user can hold to summon the picker. Backed by its
+/// raw string so it persists cleanly in UserDefaults / `@AppStorage`.
+enum TriggerModifier: String, CaseIterable {
+    case command, option, control, shift
+
+    var flag: NSEvent.ModifierFlags {
+        switch self {
+        case .command: .command
+        case .option: .option
+        case .control: .control
+        case .shift: .shift
+        }
+    }
+
+    /// The glyph shown on the Settings segmented control.
+    var symbol: String {
+        switch self {
+        case .command: "\u{2318}"   // ⌘
+        case .option: "\u{2325}"    // ⌥
+        case .control: "\u{2303}"   // ⌃
+        case .shift: "\u{21E7}"     // ⇧
+        }
+    }
+
+    var name: String {
+        switch self {
+        case .command: "Command"
+        case .option: "Option"
+        case .control: "Control"
+        case .shift: "Shift"
+        }
+    }
+
+    /// Whether this modifier is physically held *right now*. Read the instant a
+    /// link arrives (moments after the click), so a still-held key is detected —
+    /// this is a snapshot of hardware state and needs no special permission.
+    var isHeld: Bool {
+        NSEvent.modifierFlags.contains(flag)
+    }
+}
 
 /// v1 preferences, backed by UserDefaults (Decision: UserDefaults for prefs).
 enum Preferences {
@@ -9,6 +51,9 @@ enum Preferences {
     static let lastUsedTargetKey = "lastUsedTargetID"
     static let targetOrderKey = "targetOrder"
     static let hiddenTargetsKey = "hiddenTargets"
+    static let requireModifierKey = "requireModifierForPicker"
+    static let triggerModifierKey = "triggerModifier"
+    static let defaultTargetKey = "defaultTargetID"
 
     /// Pre-highlight whatever you picked last time.
     static var rememberLast: Bool {
@@ -30,6 +75,26 @@ enum Preferences {
     static var lastUsedTargetID: String? {
         get { UserDefaults.standard.string(forKey: lastUsedTargetKey) }
         set { UserDefaults.standard.set(newValue, forKey: lastUsedTargetKey) }
+    }
+
+    /// When on, a plain click opens `defaultTargetID` directly; the picker only
+    /// appears while `triggerModifier` is held. Off (default) = always pick.
+    static var requireModifierForPicker: Bool {
+        get { UserDefaults.standard.bool(forKey: requireModifierKey) }
+        set { UserDefaults.standard.set(newValue, forKey: requireModifierKey) }
+    }
+
+    /// The key held to summon the picker in modifier mode.
+    static var triggerModifier: TriggerModifier {
+        get { TriggerModifier(rawValue: UserDefaults.standard.string(forKey: triggerModifierKey) ?? "") ?? .option }
+        set { UserDefaults.standard.set(newValue.rawValue, forKey: triggerModifierKey) }
+    }
+
+    /// The target a plain click opens in modifier mode. Nil until chosen; the
+    /// picker falls back to the top of the catalog.
+    static var defaultTargetID: String? {
+        get { UserDefaults.standard.string(forKey: defaultTargetKey) }
+        set { UserDefaults.standard.set(newValue, forKey: defaultTargetKey) }
     }
 }
 

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -13,6 +13,9 @@ struct SettingsView: View {
 
     @AppStorage(Preferences.rememberLastKey) private var rememberLast = false
     @AppStorage(Preferences.skipSingleKey) private var skipSingle = false
+    @AppStorage(Preferences.requireModifierKey) private var requireModifier = false
+    @AppStorage(Preferences.triggerModifierKey) private var triggerModifier: TriggerModifier = .option
+    @AppStorage(Preferences.defaultTargetKey) private var defaultTargetID = ""
     @State private var launchAtLogin = false
 
     @State private var draggingID: String?
@@ -64,6 +67,11 @@ struct SettingsView: View {
         isDefault = DefaultBrowser.isBrowBro
         chromeAccess = ChromeAccess.canReadLocalState()
         launchAtLogin = LoginItem.isEnabled
+        // Keep the "open plain clicks in" choice pointing at a real target:
+        // seed it on first run, and heal it if the saved browser vanished.
+        if catalog.all.first(where: { $0.id == defaultTargetID }) == nil {
+            defaultTargetID = catalog.visible.first?.id ?? catalog.all.first?.id ?? ""
+        }
     }
 
     // MARK: Default browser
@@ -179,6 +187,23 @@ struct SettingsView: View {
     private var behaviorGroup: some View {
         SettingsGroup(title: "Behavior") {
             SettingsRow(
+                label: "Ask only when I hold a key",
+                description: "Plain clicks open your default browser. Hold \(triggerModifier.symbol) to pop the picker.",
+                trailing: { BBSwitch(isOn: $requireModifier) })
+            if requireModifier {
+                BBDivider().padding(.leading, 12)
+                SettingsRow(
+                    label: "Trigger key",
+                    description: "Held while you click a link.",
+                    trailing: { ModifierPicker(selection: $triggerModifier) })
+                BBDivider().padding(.leading, 12)
+                SettingsRow(
+                    label: "Open plain clicks in",
+                    description: "The browser a link opens in when you don't hold \(triggerModifier.symbol).",
+                    trailing: { defaultTargetPicker })
+            }
+            BBDivider().padding(.leading, 12)
+            SettingsRow(
                 label: "Remember last used",
                 description: "Pre-highlight whatever you picked last time.",
                 trailing: { BBSwitch(isOn: $rememberLast) })
@@ -200,6 +225,21 @@ struct SettingsView: View {
                         }))
                 })
         }
+        .animation(BBMotion.easeOut(BBMotion.panel), value: requireModifier)
+    }
+
+    /// Native popup to choose which browser a plain click opens in (modifier
+    /// mode). Lists the whole catalog so a hidden target can still be the default.
+    private var defaultTargetPicker: some View {
+        Picker("", selection: $defaultTargetID) {
+            ForEach(catalog.all) { target in
+                Text(target.name).tag(target.id)
+            }
+        }
+        .labelsHidden()
+        .pickerStyle(.menu)
+        .tint(BB.accent)
+        .fixedSize()
     }
 
     // MARK: Updates
@@ -469,6 +509,43 @@ private struct GripDots: View {
         }
         .foregroundStyle(BB.iconSecondary)
         .frame(width: 16, height: 16)
+    }
+}
+
+// MARK: - Modifier segmented control (⌘ ⌥ ⌃ ⇧)
+// The trigger-key chooser for "ask only when I hold a key". Styled from the
+// tokens so the on-state reads as BrowBro Blue, not the system accent.
+
+private struct ModifierPicker: View {
+    @Binding var selection: TriggerModifier
+
+    var body: some View {
+        HStack(spacing: 4) {
+            ForEach(TriggerModifier.allCases, id: \.self) { mod in
+                let on = mod == selection
+                Button {
+                    selection = mod
+                } label: {
+                    Text(mod.symbol)
+                        .font(.system(size: 13, weight: .medium))
+                        .frame(width: 28, height: 22)
+                        .foregroundStyle(on ? BB.onAccent : BB.textSecondary)
+                        .background(
+                            on ? BB.accentFill : BB.fillQuiet,
+                            in: RoundedRectangle(cornerRadius: BB.radiusSM, style: .continuous))
+                        .overlay {
+                            if !on {
+                                RoundedRectangle(cornerRadius: BB.radiusSM, style: .continuous)
+                                    .strokeBorder(BB.borderHairline, lineWidth: BB.hairline)
+                            }
+                        }
+                }
+                .buttonStyle(.plain)
+                .cursor(.pointingHand)
+                .help(mod.name)
+            }
+        }
+        .animation(BBMotion.easeOut(BBMotion.instant), value: selection)
     }
 }
 


### PR DESCRIPTION
## Summary

Adds a **Settings → Behavior** option, **"Ask only when I hold a key"**. When on, a plain click opens your chosen default browser directly, and the picker only pops when you hold a modifier while clicking.

- **Trigger key** is configurable (⌘ / ⌥ / ⌃ / ⇧, default **⌥** — least likely to be swallowed by the source app).
- **"Open plain clicks in"** chooses the browser a plain click routes to; it can be a target you've hidden from the picker, and self-heals if that browser disappears.
- The held modifier is read from `NSEvent.modifierFlags` the instant the link's Apple Event arrives (moments after the click), so a still-held key is detected — no accessibility permission needed. Same technique Velja/Choosy use.
- **Off by default**, so the always-show-picker behavior is unchanged.

This was already on the roadmap in `DESIGN.md` as "hold-modifier-to-bypass".

## Type of change

- [x] `feat` — new feature

## Target branch

- [x] This PR targets `develop` (default for `feat/`, `fix/`, `chore/`, etc.)

## How was this tested?

- `xcodebuild` Debug builds clean.
- Installed to `/Applications` via `./build.sh` and ran on macOS. With the option off, the picker shows as before; with it on, `open -a BrowBro <url>` (no key held) routes straight to the default target, and holding ⌥ while clicking a real link pops the picker.

## Checklist

- [x] My branch follows the naming convention (`feat/`)
- [x] My PR title follows Conventional Commits (it becomes the squash-merge commit message)
- [x] I've updated `CHANGELOG.md` under `[Unreleased]`
- [x] I've updated documentation if needed (`DESIGN.md`)