### PR TITLE
chore: sync v0.1.5 release into develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5] - 2026-07-06
+
 ### Added
 
 - **Hold a key to pick.** A new **Settings → Behavior** option, "Ask only when I hold a key",
@@ -88,7 +90,8 @@ yet notarized, so the first launch needs a manual "Open Anyway" (see the release
 - Marketing website (static, in `site/`) published to GitHub Pages at browbro.tiagomoraes.cloud.
 - Project scaffolding: Gitflow branching model, contribution guidelines, issue/PR templates.
 
-[Unreleased]: https://github.com/tiagomoraes/browbro/compare/v0.1.4...HEAD
+[Unreleased]: https://github.com/tiagomoraes/browbro/compare/v0.1.5...HEAD
+[0.1.5]: https://github.com/tiagomoraes/browbro/compare/v0.1.4...v0.1.5
 [0.1.4]: https://github.com/tiagomoraes/browbro/compare/v0.1.3...v0.1.4
 [0.1.3]: https://github.com/tiagomoraes/browbro/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/tiagomoraes/browbro/compare/v0.1.1...v0.1.2

--- a/project.yml
+++ b/project.yml
@@ -14,10 +14,10 @@ packages:
 settings:
   base:
     PRODUCT_BUNDLE_IDENTIFIER: so.aca.browbro
-    MARKETING_VERSION: "0.1.4"
+    MARKETING_VERSION: "0.1.5"
     # CFBundleVersion. Sparkle compares this to decide if an update is newer, so
     # it MUST increase on every public release (see docs/UPDATES.md).
-    CURRENT_PROJECT_VERSION: "4"
+    CURRENT_PROJECT_VERSION: "5"
     # Swift 5 language mode keeps the prototype free of strict-concurrency
     # noise; we can tighten to Swift 6 mode once the slice is proven.
     SWIFT_VERSION: "5.0"

--- a/site/appcast.xml
+++ b/site/appcast.xml
@@ -6,6 +6,23 @@
     <description>In-app update feed for BrowBro. Each item is EdDSA-signed; see docs/UPDATES.md.</description>
     <language>en</language>
     <item>
+      <title>Version 0.1.5</title>
+      <link>https://github.com/tiagomoraes/browbro/releases/tag/v0.1.5</link>
+      <sparkle:version>5</sparkle:version>
+      <sparkle:shortVersionString>0.1.5</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
+      <pubDate>Mon, 06 Jul 2026 18:03:53 +0000</pubDate>
+      <description><![CDATA[
+<h4>Added</h4>
+<ul>
+<li><strong>Hold a key to pick.</strong> A new <strong>Settings → Behavior</strong> option, "Ask only when I hold a key", makes a plain click open your default browser straight away and only pops the picker when you hold a modifier while clicking. Choose the trigger key (⌘ / ⌥ / ⌃ / ⇧, default ⌥) and which browser plain clicks open in. The picker's always-on behavior is unchanged when the option is off.</li>
+</ul>
+      ]]></description>
+      <enclosure url="https://github.com/tiagomoraes/browbro/releases/download/v0.1.5/BrowBro.dmg"
+                 sparkle:edSignature="uVNgpOF4Hgzv2X3g/tOIp6y2eOk9h5yZ2PX1eymqh2CdFp5qOmJ0LtP434K4otZ6xGaQ/DdT6ropk0ia6NYJBw==" length="2656301"
+                 type="application/x-apple-diskimage" />
+    </item>
+    <item>
       <title>Version 0.1.4</title>
       <link>https://github.com/tiagomoraes/browbro/releases/tag/v0.1.4</link>
       <sparkle:version>4</sparkle:version>


### PR DESCRIPTION
Gitflow back-merge: brings the v0.1.5 version bump (`project.yml`) and the published `site/appcast.xml` back into `develop` so the next release doesn't start from stale state.

## Target branch
- [x] Targets `develop`