### PR TITLE
feat: private windows — opt-in incognito/private launch targets

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: verify
+description: Build, install, and drive BrowBro to observe a change at its real surface (picker, launches). Use when verifying that a code change works end-to-end.
+---
+
+# Verifying BrowBro changes
+
+## Build + install + launch
+
+`./build.sh` — xcodegen + xcodebuild + install to /Applications + relaunch. This is the
+whole handle; there is no test target.
+
+## Back up prefs first
+
+Verification usually means mutating prefs. Snapshot and restore exactly:
+
+```bash
+defaults export so.aca.browbro /tmp/browbro-prefs-backup.plist
+# … drive …
+defaults delete so.aca.browbro && defaults import so.aca.browbro /tmp/browbro-prefs-backup.plist
+```
+
+## Drive a link WITHOUT changing the default browser
+
+```bash
+open -a BrowBro "https://example.com/my-test"
+```
+
+The picker pops at the cursor. Dismiss without launching by activating another app
+(`osascript -e 'tell application "Finder" to activate'`).
+
+## Drive a launch with NO UI interaction
+
+Modifier mode opens `defaultTargetID` directly on a plain link — a programmatic path
+through `BrowserLauncher.launch`:
+
+```bash
+defaults write so.aca.browbro requireModifierForPicker -bool true
+defaults write so.aca.browbro defaultTargetID "app:com.google.Chrome"   # any target id
+open -a BrowBro "https://example.com/launch-test"
+```
+
+## Observe
+
+- **Decisions**: `/usr/bin/log show --last 5m --info --predicate 'subsystem == "so.aca.browbro"'`
+  — the picker logs presented targets and which target a launch resolved to. Use the full
+  path (`log` is a zsh builtin) and remember `--info`.
+- **Pixels**: `screencapture -x /tmp/shot.png` then Read the image. Fails silently to a
+  lock-screen shot if the screen locked mid-run — check what you captured.
+- **Window titles** (works even when AppleScript to Chrome times out — it does when a
+  devtools-automation Chrome instance is around): CGWindowList via a scratch Swift script;
+  Chrome's owner name is "Google Chrome", Firefox's is "Firefox". Firefox private windows
+  are titled "… — Private Browsing".
+- **Incognito proof**: incognito writes no history. Copy the profile's
+  `~/Library/Application Support/Google/Chrome/<Profile>/History` and
+  `sqlite3 … "SELECT count(*) FROM urls WHERE url LIKE '%my-test%'"` — 0 hits while the
+  window exists is the signature.
+
+## Gotchas
+
+- Target ids: `app:<bundleID>`, `chrome:<profile dir>`, `private:<base-id>`.
+- `defaults write` while BrowBro runs is fine — the catalog refreshes on every link.
+- Debug build replaces the installed app; that's the sanctioned dev loop.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Private windows.** A new **Settings → Private windows** switch adds picker entries that
+  open links in a browser's incognito/private window — per browser and even per Chrome
+  profile ("Work Incognito" opens that profile's incognito window). Supported for Chrome,
+  Chromium, Brave, Edge, Vivaldi, Opera, and Firefox; entries wear a sunglasses badge so a
+  private pick is unmistakable. Safari is not supported (it offers no way to open a private
+  window programmatically).
+
 ## [0.1.5] - 2026-07-06
 
 ### Added

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,51 @@
+# BrowBro
+
+A macOS menu-bar app that intercepts clicked links and pops a keyboard-first picker at the
+cursor, so every link opens in the right browser or Chrome profile.
+
+## Language
+
+**Launch Target**:
+A single pickable destination in the Picker.
+_Avoid_: browser option, entry, item
+
+**Browser**:
+An installed app registered to handle http(s) links.
+
+**Chrome Profile**:
+A specific Chrome user profile, pickable as its own Launch Target.
+_Avoid_: account, persona
+
+**Private Window**:
+A browsing session that persists no history or cookies once closed, opened as a window (the
+browser decides tab placement — BrowBro cannot control it).
+_Avoid_: anonymous tab, incognito (Chrome-only dialect), private tab, private mode
+
+**Picker**:
+The keyboard-first popover listing Launch Targets when a link is clicked.
+
+**Trigger Modifier**:
+The key held to summon the Picker when plain clicks bypass it — it gates *whether* the
+Picker appears, never *how* a pick behaves.
+_Avoid_: hotkey, shortcut
+
+## Relationships
+
+- The **Picker** lists **Launch Targets** in the user's saved order.
+- A **Launch Target** is a **Browser**, a **Chrome Profile**, or a **Private Window** variant
+  of either.
+- Only Browsers with a known private-window capability (and their Chrome Profiles) offer a
+  **Private Window** variant; Safari offers none.
+
+## Example dialogue
+
+> **Dev:** "When someone picks the **Private Window** target, do we open a tab in an
+> existing incognito window?"
+> **Domain expert:** "We ask the **Browser** for a **Private Window**; whether it reuses an
+> open one and adds a tab is the browser's call, not ours."
+
+## Flagged ambiguities
+
+- "anonymous tab" was used to mean **Private Window** — resolved: it is a window-level
+  concept and named vendor-neutrally; per-browser UI copy may still use the browser's own
+  dialect (e.g. "Incognito" for Chrome).

--- a/Sources/BrowserLauncher.swift
+++ b/Sources/BrowserLauncher.swift
@@ -16,19 +16,19 @@ enum BrowserLauncher {
         NSWorkspace.shared.urlForApplication(withBundleIdentifier: "com.google.Chrome")
     }
 
-    /// Open a URL in Chrome routed to a specific profile directory (e.g. "Profile 1").
+    /// Open a URL by invoking the browser's *binary* directly with launch flags.
     ///
-    /// We invoke the Chrome *binary* directly rather than `NSWorkspace.open`, because
-    /// `--profile-directory` is only honored as a launch argument. Chrome dedupes to
-    /// its running instance, so this opens a tab in the chosen profile whether or not
-    /// Chrome is already open.
+    /// Flags like `--profile-directory` and `--incognito` are only honored as launch
+    /// arguments — `NSWorkspace.open` can't deliver them to a running app. These
+    /// browsers dedupe to their running instance, so this opens the right window
+    /// whether or not the browser is already open (verified live for Chrome and
+    /// Firefox — ADR-0001). The binary comes from the bundle's CFBundleExecutable.
     @discardableResult
-    static func openInChrome(_ url: URL, profileDirectory: String, chromeAppURL: URL? = nil) -> Bool {
-        guard let appURL = chromeAppURL ?? self.chromeAppURL() else { return false }
-        let binary = appURL.appendingPathComponent("Contents/MacOS/Google Chrome")
+    static func open(_ url: URL, withBinaryOfAppAt appURL: URL, flags: [String]) -> Bool {
+        guard let binary = Bundle(url: appURL)?.executableURL else { return false }
         let process = Process()
         process.executableURL = binary
-        process.arguments = ["--profile-directory=\(profileDirectory)", url.absoluteString]
+        process.arguments = flags + [url.absoluteString]
         do {
             try process.run()
             return true
@@ -37,13 +37,20 @@ enum BrowserLauncher {
         }
     }
 
-    /// Launch a resolved target (browser app or Chrome profile) with a URL.
+    /// Launch a resolved target (browser, Chrome profile, or a Private Window
+    /// variant of either) with a URL.
     static func launch(_ target: LaunchTarget, url: URL) {
-        switch target.kind {
-        case .browser:
+        var flags: [String] = []
+        if case .chromeProfile(let directory) = target.kind {
+            flags.append("--profile-directory=\(directory)")
+        }
+        if let privateFlag = target.privateFlag {
+            flags.append(privateFlag)
+        }
+        if flags.isEmpty {
             open(url, withAppAt: target.appURL)
-        case .chromeProfile(let directory):
-            openInChrome(url, profileDirectory: directory, chromeAppURL: target.appURL)
+        } else {
+            open(url, withBinaryOfAppAt: target.appURL, flags: flags)
         }
     }
 }

--- a/Sources/Controls.swift
+++ b/Sources/Controls.swift
@@ -254,6 +254,26 @@ struct AppIconChip: View {
     }
 }
 
+// MARK: - Private Window badge
+// Corner badge over a target's icon or swatch: a privacy pick must be
+// unmistakable at a glance, in the picker and in Settings alike.
+
+struct PrivateBadge: View {
+    var size: CGFloat = 13
+
+    var body: some View {
+        Circle()
+            .fill(Color(white: 0.16))
+            .frame(width: size, height: size)
+            .overlay(
+                Image(systemName: "sunglasses.fill")
+                    .font(.system(size: size * 0.55, weight: .semibold))
+                    .foregroundStyle(.white))
+            .overlay(Circle().strokeBorder(.white.opacity(0.35), lineWidth: BB.hairline))
+            .accessibilityLabel("Private window")
+    }
+}
+
 // MARK: - Hairline divider
 
 struct BBDivider: View {

--- a/Sources/LaunchTarget.swift
+++ b/Sources/LaunchTarget.swift
@@ -1,6 +1,7 @@
 import Foundation
 
-/// A single pickable destination: either a browser app, or a specific Chrome profile.
+/// A single pickable destination: a browser app, a specific Chrome profile,
+/// or a Private Window variant of either.
 struct LaunchTarget: Identifiable, Hashable {
     enum Kind: Hashable {
         case browser
@@ -14,4 +15,7 @@ struct LaunchTarget: Identifiable, Hashable {
     let bundleID: String
     let kind: Kind
     let colorARGB: Int?       // Chrome profile highlight color, else nil
+    var privateFlag: String? = nil  // launch argument for a Private Window variant, else nil
+
+    var isPrivate: Bool { privateFlag != nil }
 }

--- a/Sources/PickerView.swift
+++ b/Sources/PickerView.swift
@@ -149,10 +149,18 @@ struct TargetRowView: View {
     }
 
     @ViewBuilder private var leading: some View {
-        if case .chromeProfile = target.kind {
-            ProfileSwatch(name: target.name, colorARGB: target.colorARGB)
-        } else {
-            AppIconChip(appURL: target.appURL)
+        Group {
+            if case .chromeProfile = target.kind {
+                ProfileSwatch(name: target.name, colorARGB: target.colorARGB)
+            } else {
+                AppIconChip(appURL: target.appURL)
+            }
+        }
+        .overlay(alignment: .bottomTrailing) {
+            if target.isPrivate {
+                PrivateBadge()
+                    .offset(x: 3, y: 3)
+            }
         }
     }
 }

--- a/Sources/Preferences.swift
+++ b/Sources/Preferences.swift
@@ -54,6 +54,8 @@ enum Preferences {
     static let requireModifierKey = "requireModifierForPicker"
     static let triggerModifierKey = "triggerModifier"
     static let defaultTargetKey = "defaultTargetID"
+    static let privateWindowsEnabledKey = "privateWindowsEnabled"
+    static let privateEnabledTargetsKey = "privateEnabledTargets"
 
     /// Pre-highlight whatever you picked last time.
     static var rememberLast: Bool {
@@ -95,6 +97,20 @@ enum Preferences {
     static var defaultTargetID: String? {
         get { UserDefaults.standard.string(forKey: defaultTargetKey) }
         set { UserDefaults.standard.set(newValue, forKey: defaultTargetKey) }
+    }
+
+    /// Master switch for the Private Windows feature. Off (default) = no
+    /// Private Window variants exist anywhere; per-target opt-ins are kept so
+    /// switching back on restores them.
+    static var privateWindowsEnabled: Bool {
+        get { UserDefaults.standard.bool(forKey: privateWindowsEnabledKey) }
+        set { UserDefaults.standard.set(newValue, forKey: privateWindowsEnabledKey) }
+    }
+
+    /// Base-target ids the user opted into a Private Window variant for.
+    static var privateEnabledTargets: [String] {
+        get { UserDefaults.standard.stringArray(forKey: privateEnabledTargetsKey) ?? [] }
+        set { UserDefaults.standard.set(newValue, forKey: privateEnabledTargetsKey) }
     }
 }
 

--- a/Sources/PrivateWindow.swift
+++ b/Sources/PrivateWindow.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// Which browsers can open a Private Window from the command line, and how.
+/// Only browsers listed here offer a Private Window variant — Safari has no
+/// programmatic path, and a privacy feature that silently opened a normal
+/// window would be worse than not offering one (ADR-0001).
+enum PrivateWindow {
+    struct Capability {
+        /// The launch argument that opens a private window.
+        let flag: String
+        /// The browser's own word for it, used in the variant's display name
+        /// ("Chrome Incognito", "Edge InPrivate", "Firefox Private").
+        let dialect: String
+    }
+
+    /// Known private-capable browsers by bundle id.
+    private static let table: [String: Capability] = [
+        // Chromium family
+        "com.google.Chrome": .init(flag: "--incognito", dialect: "Incognito"),
+        "com.google.Chrome.beta": .init(flag: "--incognito", dialect: "Incognito"),
+        "com.google.Chrome.canary": .init(flag: "--incognito", dialect: "Incognito"),
+        "org.chromium.Chromium": .init(flag: "--incognito", dialect: "Incognito"),
+        "com.brave.Browser": .init(flag: "--incognito", dialect: "Private"),
+        "com.vivaldi.Vivaldi": .init(flag: "--incognito", dialect: "Private"),
+        "com.microsoft.edgemac": .init(flag: "--inprivate", dialect: "InPrivate"),
+        "com.operasoftware.Opera": .init(flag: "--private", dialect: "Private"),
+        // Firefox family
+        "org.mozilla.firefox": .init(flag: "--private-window", dialect: "Private"),
+        "org.mozilla.firefoxdeveloperedition": .init(flag: "--private-window", dialect: "Private"),
+        "org.mozilla.nightly": .init(flag: "--private-window", dialect: "Private"),
+    ]
+
+    static func capability(for bundleID: String) -> Capability? {
+        table[bundleID]
+    }
+}

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -16,6 +16,7 @@ struct SettingsView: View {
     @AppStorage(Preferences.requireModifierKey) private var requireModifier = false
     @AppStorage(Preferences.triggerModifierKey) private var triggerModifier: TriggerModifier = .option
     @AppStorage(Preferences.defaultTargetKey) private var defaultTargetID = ""
+    @AppStorage(Preferences.privateWindowsEnabledKey) private var privateWindowsEnabled = false
     @State private var launchAtLogin = false
 
     @State private var draggingID: String?
@@ -31,6 +32,7 @@ struct SettingsView: View {
                         chromeGroup
                     }
                     catalogGroup
+                    privateWindowsGroup
                     behaviorGroup
                     updatesGroup
                     supportGroup
@@ -180,6 +182,53 @@ struct SettingsView: View {
                 }
             }
         }
+    }
+
+    // MARK: Private windows
+
+    /// The Private Windows feature: a master switch, then one opt-in row per
+    /// private-capable target. Variants are derived at discovery (ADR-0001),
+    /// so every toggle just refreshes the catalog.
+    private var privateWindowsGroup: some View {
+        SettingsGroup(title: "Private windows") {
+            SettingsRow(
+                leading: {
+                    Image(systemName: "sunglasses.fill")
+                        .font(.system(size: 15, weight: .medium))
+                        .foregroundStyle(BB.iconSecondary)
+                },
+                label: "Open links in private windows",
+                description: "Add picker entries that open a browser's incognito or private window.",
+                trailing: { BBSwitch(isOn: $privateWindowsEnabled) })
+            if privateWindowsEnabled {
+                ForEach(privateCapableBases) { base in
+                    BBDivider().padding(.leading, 12)
+                    PrivateOptInRow(
+                        base: base,
+                        dialect: PrivateWindow.capability(for: base.bundleID)?.dialect ?? "Private",
+                        enabled: Preferences.privateEnabledTargets.contains(base.id),
+                        onToggle: { togglePrivateVariant(base.id) })
+                }
+            }
+        }
+        .animation(BBMotion.easeOut(BBMotion.panel), value: privateWindowsEnabled)
+        .onChange(of: privateWindowsEnabled) { _, _ in catalog.refresh() }
+    }
+
+    /// Base (non-variant) targets that can open a Private Window, in catalog order.
+    private var privateCapableBases: [LaunchTarget] {
+        catalog.all.filter { !$0.isPrivate && PrivateWindow.capability(for: $0.bundleID) != nil }
+    }
+
+    private func togglePrivateVariant(_ baseID: String) {
+        var enabled = Set(Preferences.privateEnabledTargets)
+        if enabled.contains(baseID) {
+            enabled.remove(baseID)
+        } else {
+            enabled.insert(baseID)
+        }
+        Preferences.privateEnabledTargets = Array(enabled)
+        catalog.refresh()
     }
 
     // MARK: Behavior
@@ -480,18 +529,69 @@ private struct CatalogRow: View {
     }
 
     @ViewBuilder private var leading: some View {
-        if case .chromeProfile = target.kind {
-            ProfileSwatch(name: target.name, colorARGB: target.colorARGB, size: 22)
-        } else {
-            AppIconChip(appURL: target.appURL, size: 22)
+        Group {
+            if case .chromeProfile = target.kind {
+                ProfileSwatch(name: target.name, colorARGB: target.colorARGB, size: 22)
+            } else {
+                AppIconChip(appURL: target.appURL, size: 22)
+            }
+        }
+        .overlay(alignment: .bottomTrailing) {
+            if target.isPrivate {
+                PrivateBadge(size: 11)
+                    .offset(x: 2.5, y: 2.5)
+            }
         }
     }
 
     private var subtitle: String {
+        if target.isPrivate {
+            if case .chromeProfile = target.kind {
+                return target.subtitle.map { "Private window · \($0)" } ?? "Private window"
+            }
+            return "Private window"
+        }
         if case .chromeProfile = target.kind {
             return target.subtitle.map { "Chrome · \($0)" } ?? "Chrome profile"
         }
         return "Web browser"
+    }
+}
+
+// MARK: - Private Window opt-in row (switch adds/removes the variant)
+
+private struct PrivateOptInRow: View {
+    let base: LaunchTarget
+    let dialect: String
+    let enabled: Bool
+    let onToggle: () -> Void
+
+    var body: some View {
+        HStack(spacing: 8) {
+            leading
+            VStack(alignment: .leading, spacing: 1) {
+                Text(base.name)
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(BB.textPrimary)
+                    .lineLimit(1)
+                Text("Adds “\(base.name) \(dialect)” to the picker.")
+                    .font(BBFont.caption)
+                    .foregroundStyle(BB.textSecondary)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            Spacer(minLength: 8)
+            BBSwitch(isOn: Binding(get: { enabled }, set: { _ in onToggle() }))
+        }
+        .padding(EdgeInsets(top: 8, leading: 12, bottom: 8, trailing: 10))
+    }
+
+    @ViewBuilder private var leading: some View {
+        if case .chromeProfile = base.kind {
+            ProfileSwatch(name: base.name, colorARGB: base.colorARGB, size: 22)
+        } else {
+            AppIconChip(appURL: base.appURL, size: 22)
+        }
     }
 }
 

--- a/Sources/TargetDiscovery.swift
+++ b/Sources/TargetDiscovery.swift
@@ -32,7 +32,29 @@ enum TargetDiscovery {
         }
     }
 
+    /// Private Window variants of opted-in base targets. Derived, never
+    /// persisted: they exist only while the master switch is on and the base
+    /// target is opted in, so toggling off or uninstalling the browser removes
+    /// them and saved ids dangle harmlessly (ADR-0001).
+    static func privateVariants(of bases: [LaunchTarget]) -> [LaunchTarget] {
+        guard Preferences.privateWindowsEnabled else { return [] }
+        let enabled = Set(Preferences.privateEnabledTargets)
+        return bases.compactMap { base in
+            guard enabled.contains(base.id),
+                  let capability = PrivateWindow.capability(for: base.bundleID) else { return nil }
+            return LaunchTarget(id: "private:\(base.id)",
+                                name: "\(base.name) \(capability.dialect)",
+                                subtitle: base.subtitle,
+                                appURL: base.appURL,
+                                bundleID: base.bundleID,
+                                kind: base.kind,
+                                colorARGB: base.colorARGB,
+                                privateFlag: capability.flag)
+        }
+    }
+
     static func all() -> [LaunchTarget] {
-        browsers() + chromeProfiles()
+        let bases = browsers() + chromeProfiles()
+        return bases + privateVariants(of: bases)
     }
 }

--- a/docs/adr/0001-private-windows-as-derived-opt-in-targets.md
+++ b/docs/adr/0001-private-windows-as-derived-opt-in-targets.md
@@ -1,0 +1,41 @@
+# Private Windows are derived, opt-in Launch Targets
+
+Users want links to open in an incognito/private window of a chosen browser. We modeled
+this as a **variant Launch Target** (a separate picker entry per browser or Chrome
+profile), not a pick-time modifier key, because the flat target catalog already gives every
+entry a digit, position, visibility, remember-last, and default-target semantics for free —
+and a modifier would collide with the existing Trigger Modifier ("hold to summon"), which
+gates *whether* the picker appears, never *how* a pick behaves.
+
+## Consequences
+
+- **Derived, never persisted.** Variants are regenerated at discovery with deterministic
+  ids `private:<base-id>` (e.g. `private:app:com.google.Chrome`,
+  `private:chrome:Profile 1`). They exist only while (a) the master "Private Windows"
+  switch is on and (b) the base target is in the per-target opt-in set. Uninstalling the
+  browser or toggling off removes them; saved order/default/last-used ids dangle harmlessly
+  (existing fallbacks cover this). The id scheme is effectively frozen — it is written into
+  users' persisted preferences.
+- **Capability table, not universal.** Only browsers with a known private-window launch
+  flag offer the variant: Chromium family `--incognito`, Edge `--inprivate`, Opera
+  `--private`, Firefox family `--private-window`. Safari is excluded — it has no
+  programmatic path short of Accessibility-permission UI scripting, and a privacy feature
+  that silently opens a normal window would destroy trust. Adding a browser = adding a
+  table row.
+- **Direct binary invocation, not NSWorkspace.** Launch flags are only honored as process
+  arguments, and these browsers dedupe to their running instance (verified live against a
+  running Chrome: `--profile-directory="Profile 1" --incognito <url>` → "Opening in
+  existing browser session."). This extends the pattern `openInChrome` already established
+  for `--profile-directory`.
+- **Chrome profiles compose.** An incognito window belongs to a profile (extensions,
+  enterprise policy), so a Private Window variant of a specific Chrome Profile launches
+  `--profile-directory=X --incognito` deterministically; a browser-level Chrome variant
+  inherits the last-active profile.
+- **Firefox verified on macOS.** The historic "already open" failure when invoking the
+  binary against a running instance is gone: on Firefox 152, `firefox --private-window
+  <url>` forwards to the running instance and exits in <1s, and a cold start opens straight
+  into a private window. (Binary name comes from `CFBundleExecutable`, not a hardcoded
+  path — Firefox's is `firefox`, Chrome's is `Google Chrome`.)
+- **Naming uses each browser's dialect** ("Chrome Incognito", "Edge InPrivate", "Firefox
+  Private") because names must be unique in name-only dropdowns and users recognize their
+  browser's own word; the canonical domain term stays **Private Window** (CONTEXT.md).


### PR DESCRIPTION
## What

A new **Settings → Private windows** master switch adds picker entries that open links in a browser's incognito/private window — per browser **and per Chrome profile** ("acaso Incognito" deterministically opens that profile's incognito via `--profile-directory=X --incognito`). Entries use each browser's own dialect ("Chrome Incognito", "Edge InPrivate", "Firefox Private") and wear a sunglasses badge in the picker and Settings so a private pick is unmistakable.

With the master switch off (default), no variants exist anywhere — picker, catalog, or default-target dropdown — and per-target opt-ins are preserved for re-enabling.

## Design (see CONTEXT.md + ADR-0001, added here)

- **Derived, never persisted.** Variants regenerate at discovery with id `private:<base-id>`, gated on the master switch + a per-target opt-in set. Uninstalling or toggling off removes them; dangling saved ids fall back through existing mechanics.
- **Capability table, not universal.** Chrome/Chromium/Brave/Vivaldi `--incognito`, Edge `--inprivate`, Opera `--private`, Firefox family `--private-window`. Safari excluded: it has no programmatic path, and a privacy feature that silently opened a normal window would destroy trust. New browser = one table row.
- **Direct binary invocation** generalizes the existing Chrome-profile pattern; the binary name comes from `CFBundleExecutable`.

## Verified live (debug build installed, driven via `open -a BrowBro <url>`)

- Picker rendered all variants with badges; Safari in the opt-in set correctly produced nothing.
- `Google Chrome Incognito` pick → new Chrome window, **zero history rows in all five profiles** while the window was open (the incognito signature).
- `acaso Incognito` (Chrome Profile 1 variant) → per-profile incognito, no history trace.
- `Firefox Private` → window titled "Example Domain — Private Browsing" (Firefox 152); hot forward to a running instance and cold start both confirmed.
- Master switch off with a dangling `private:` default target → clean fallback to the first visible target (logged "opening Personal").

🤖 Generated with [Claude Code](https://claude.com/claude-code)